### PR TITLE
Improve enemy hit reactions, skip intro, and add HUD

### DIFF
--- a/LegacyoftheAbyss.csproj
+++ b/LegacyoftheAbyss.csproj
@@ -24,6 +24,10 @@
         <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
     </Reference>
 
+    <Reference Include="UnityEngine.UI">
+      <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.UI.dll</HintPath>
+    </Reference>
+
 
 
 


### PR DESCRIPTION
## Summary
- Use Hit/TakeHit with HitInstance for projectile damage so enemies react like Hornet's needle
- Skip Team Cherry logo and save reminder for faster boot
- Add top-right HUD showing health masks and soul meter

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68c14ac4349c83208aaedfa9418a9650