### PR TITLE
Exclude DummyDLLs from compilation

### DIFF
--- a/LegacyoftheAbyss.csproj
+++ b/LegacyoftheAbyss.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="DummyDLLs/**" />
+    <EmbeddedResource Remove="DummyDLLs/**" />
+    <None Remove="DummyDLLs/**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Unity / Game Assemblies -->
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.dll</HintPath>


### PR DESCRIPTION
## Summary
- prevent `DummyDLLs` directory from being treated as build items

## Testing
- `dotnet build -c Release` *(fails: type or namespace name 'HarmonyLib' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16d8110088320a8fdca8c8a3ae377