### PR TITLE
Ignore Hornet in Descending Dark raycast

### DIFF
--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -580,6 +580,7 @@ public partial class LegacyHelper
                 if (!h.collider) continue;
                 if (h.collider.isTrigger) continue;
                 if (h.collider.transform == transform || h.collider.transform.IsChildOf(transform)) continue;
+                if (hornetTransform && (h.collider.transform == hornetTransform || h.collider.transform.IsChildOf(hornetTransform))) continue;
                 pick = h; break;
             }
 


### PR DESCRIPTION
## Summary
- skip Hornet's colliders when raycasting for Descending Dark ground detection

## Testing
- `dotnet build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68c40ef5e0908320a13dc3418b5b118d