### PR TITLE
fix: ignore hornet in shade dive

### DIFF
--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -583,8 +583,12 @@ public partial class LegacyHelper
                 var ht = h.collider.transform;
                 // ignore self (any part of the shade hierarchy)
                 if (ht == transform || ht.IsChildOf(transform) || transform.IsChildOf(ht)) continue;
-                // ignore hornet using root comparison
-                if (hornetRoot && ht.root == hornetRoot) continue;
+                // ignore hornet using hierarchy checks
+                if (hornetTransform)
+                {
+                    if (ht == hornetTransform || ht.IsChildOf(hornetTransform) || (hornetRoot && ht.root == hornetRoot))
+                        continue;
+                }
                 // ignore enemies/hazards (anything that damages hero)
                 try { if (h.collider.GetComponentInParent<DamageHero>() != null) continue; } catch { }
                 // otherwise this is acceptable ground


### PR DESCRIPTION
## Summary
- prevent shade dive from detecting Hornet as ground
- ignore Hornet's colliders when checking hazards or damage

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c41053416c832089d452d9fba0fbbf