### PR TITLE
Prevent copying referenced assemblies to plugin folder

### DIFF
--- a/LegacyoftheAbyss.csproj
+++ b/LegacyoftheAbyss.csproj
@@ -23,41 +23,53 @@
     <!-- Unity / Game Assemblies -->
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.AudioModule">
       <HintPath>..\..\..\Hollow Knight Silksong_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
 
     <!-- BepInEx Core -->
     <Reference Include="BepInEx">
       <HintPath>DummyDLLs/BepInEx.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="HarmonyLib">
       <HintPath>DummyDLLs/0Harmony.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Mark all referenced game and mod assemblies as non-private so the build only outputs `LegacyoftheAbyss.dll` and `.pdb`

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68c58e629f6083209ebf583140cd074a