### PR TITLE
Ignore enemy detection damage and add shade invincibility toggle

### DIFF
--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -35,10 +35,10 @@ public partial class SimpleHUD : MonoBehaviour
     private Canvas canvas;
     private CanvasScaler scaler;
 
-    private const KeyCode DebugDamageKey = KeyCode.Minus;
-    private const KeyCode DebugHealKey = KeyCode.Equals;
-    private const KeyCode DebugSoulDecKey = KeyCode.LeftBracket;   // [
-    private const KeyCode DebugSoulIncKey = KeyCode.RightBracket;  // ]
+    private const KeyCode DebugDamageKey = KeyCode.None; // disabled
+    private const KeyCode DebugHealKey = KeyCode.None; // disabled
+    private const KeyCode DebugSoulDecKey = KeyCode.None;   // disabled
+    private const KeyCode DebugSoulIncKey = KeyCode.None;  // disabled
     private const KeyCode DebugSoulResetKey = KeyCode.Backslash;   // \
 
     // Debug silk override (UI-only, does not write PlayerData)


### PR DESCRIPTION
## Summary
- Prevent Shade from taking damage when entering enemy attack-range triggers
- Add 0 hotkey to toggle Shade damage intake
- Disable debug hotkeys for Shade soul and health adjustments

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6375d3ce4832084264b579f6331f9