### PR TITLE
Filter enemy detection ranges and persist assist mode

### DIFF
--- a/LegacyHelper.Core.cs
+++ b/LegacyHelper.Core.cs
@@ -19,13 +19,15 @@ public partial class LegacyHelper : BaseUnityPlugin
     internal static int savedShadeMax = -1;
     internal static int savedShadeSoul = -1;
     internal static int savedShadeSpellProgress = 0; // 0..6 progression
+    internal static bool savedShadeCanTakeDamage = true;
     internal static bool HasSavedShadeState => savedShadeMax > 0;
 
-    internal static void SaveShadeState(int curHp, int maxHp, int soul)
+    internal static void SaveShadeState(int curHp, int maxHp, int soul, bool? canTakeDamage = null)
     {
         savedShadeMax = Mathf.Max(1, maxHp);
         savedShadeHP = Mathf.Clamp(curHp, 0, savedShadeMax);
         savedShadeSoul = Mathf.Max(0, soul);
+        if (canTakeDamage.HasValue) savedShadeCanTakeDamage = canTakeDamage.Value;
     }
 
     // Called when Hornet gains a new spell. Advances Shade's unlock/upgrade track.
@@ -78,7 +80,7 @@ public partial class LegacyHelper : BaseUnityPlugin
                 if (sc != null)
                 {
                     sc.TeleportToPosition(pos);
-                    SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul());
+                    SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
                 }
                 else
                 {
@@ -98,7 +100,7 @@ public partial class LegacyHelper : BaseUnityPlugin
         scNew.Init(gm.hero_ctrl.transform);
         if (HasSavedShadeState)
         {
-            scNew.RestorePersistentState(savedShadeHP, savedShadeMax, savedShadeSoul);
+            scNew.RestorePersistentState(savedShadeHP, savedShadeMax, savedShadeSoul, savedShadeCanTakeDamage);
         }
 
         var sr = helper.AddComponent<SpriteRenderer>();

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -56,7 +56,7 @@ public partial class LegacyHelper
                     if (sc != null)
                     {
                         sc.ReviveToAtLeast(1);
-                        SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul());
+                        SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
                         return;
                     }
                 }
@@ -127,7 +127,7 @@ public partial class LegacyHelper
                     if (sc != null)
                     {
                         sc.FullHealFromBench();
-                        SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul());
+                        SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Ignore enemy sight/wake/close range trigger boxes when checking shade damage
- Save and restore shade damage toggle so Assist Mode persists across scene transitions

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68c6469100648320a360d6e963fbf17f