### PR TITLE
Sanitize shade menu screens and pause shade input

### DIFF
--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -72,8 +72,22 @@ public partial class SimpleHUD : MonoBehaviour
         if (playerData == null) return;
 
         // Debug: Shade HP adjust
-        if (Input.GetKeyDown(DebugDamageKey)) { shadeHealth = Mathf.Max(0, shadeHealth - 1); try { Debug.Log("[SimpleHUD] Debug: Shade HP -1"); } catch { } }
-        if (Input.GetKeyDown(DebugHealKey))   { shadeHealth = Mathf.Min(shadeMax, shadeHealth + 1); try { Debug.Log("[SimpleHUD] Debug: Shade HP +1"); } catch { } }
+        if (Input.GetKeyDown(DebugDamageKey))
+        {
+            shadeHealth = Mathf.Max(0, shadeHealth - 1);
+            if (ModConfig.Instance.logHud)
+            {
+                try { Debug.Log("[SimpleHUD] Debug: Shade HP -1"); } catch { }
+            }
+        }
+        if (Input.GetKeyDown(DebugHealKey))
+        {
+            shadeHealth = Mathf.Min(shadeMax, shadeHealth + 1);
+            if (ModConfig.Instance.logHud)
+            {
+                try { Debug.Log("[SimpleHUD] Debug: Shade HP +1"); } catch { }
+            }
+        }
 
         // Debug soul controls (UI or Shade override)
         float sMax = shadeSoulOverride ? Mathf.Max(1f, shadeSoulMax) : Mathf.Max(1f, playerData.silkMax);
@@ -89,14 +103,20 @@ public partial class SimpleHUD : MonoBehaviour
                 }
                 catch { }
                 shadeSoul = Mathf.Min(shadeSoul + 11f, Mathf.Max(1f, shadeSoulMax));
-                try { Debug.Log("[SimpleHUD] Debug: Shade Soul +11"); } catch { }
+                if (ModConfig.Instance.logHud)
+                {
+                    try { Debug.Log("[SimpleHUD] Debug: Shade Soul +11"); } catch { }
+                }
             }
             else
             {
                 float baseVal = debugUseCustomSilk ? debugSilk : playerData.silk;
                 debugUseCustomSilk = true;
                 debugSilk = Mathf.Min(baseVal + step, sMax);
-                try { Debug.Log("[SimpleHUD] Debug: Hornet Silk +step"); } catch { }
+                if (ModConfig.Instance.logHud)
+                {
+                    try { Debug.Log("[SimpleHUD] Debug: Hornet Silk +step"); } catch { }
+                }
             }
         }
         if (Input.GetKeyDown(DebugSoulDecKey))
@@ -110,14 +130,20 @@ public partial class SimpleHUD : MonoBehaviour
                 }
                 catch { }
                 shadeSoul = Mathf.Max(shadeSoul - 11f, 0f);
-                try { Debug.Log("[SimpleHUD] Debug: Shade Soul -11"); } catch { }
+                if (ModConfig.Instance.logHud)
+                {
+                    try { Debug.Log("[SimpleHUD] Debug: Shade Soul -11"); } catch { }
+                }
             }
             else
             {
                 float baseVal = debugUseCustomSilk ? debugSilk : playerData.silk;
                 debugUseCustomSilk = true;
                 debugSilk = Mathf.Max(baseVal - step, 0f);
-                try { Debug.Log("[SimpleHUD] Debug: Hornet Silk -step"); } catch { }
+                if (ModConfig.Instance.logHud)
+                {
+                    try { Debug.Log("[SimpleHUD] Debug: Hornet Silk -step"); } catch { }
+                }
             }
         }
         if (Input.GetKeyDown(DebugSoulResetKey))
@@ -131,13 +157,19 @@ public partial class SimpleHUD : MonoBehaviour
                 }
                 catch { }
                 shadeSoul = 0f;
-                try { Debug.Log("[SimpleHUD] Debug: Shade Soul reset"); } catch { }
+                if (ModConfig.Instance.logHud)
+                {
+                    try { Debug.Log("[SimpleHUD] Debug: Shade Soul reset"); } catch { }
+                }
             }
             else
             {
                 debugUseCustomSilk = false;
                 debugSilk = playerData.silk;
-                try { Debug.Log("[SimpleHUD] Debug: Hornet Silk reset"); } catch { }
+                if (ModConfig.Instance.logHud)
+                {
+                    try { Debug.Log("[SimpleHUD] Debug: Hornet Silk reset"); } catch { }
+                }
             }
         }
 

--- a/LegacyHelper.Core.cs
+++ b/LegacyHelper.Core.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Reflection;
 using BepInEx;
 using HarmonyLib;
@@ -65,7 +64,8 @@ public partial class LegacyHelper : BaseUnityPlugin
         {
             if (!loggedMissingUI)
             {
-                Logger.LogInfo("UIManager not found yet");
+                if (ModConfig.Instance.logGeneral)
+                    Logger.LogInfo("UIManager not found yet");
                 loggedMissingUI = true;
             }
             return;
@@ -74,7 +74,8 @@ public partial class LegacyHelper : BaseUnityPlugin
         {
             if (!loggedMissingPauseMenu)
             {
-                Logger.LogInfo("pauseMenuScreen not available yet");
+                if (ModConfig.Instance.logGeneral)
+                    Logger.LogInfo("pauseMenuScreen not available yet");
                 loggedMissingPauseMenu = true;
             }
             return;
@@ -100,16 +101,15 @@ public partial class LegacyHelper : BaseUnityPlugin
             var gm = GameManager.instance;
             if (gm == null || gm.hero_ctrl == null) return;
             Vector3 spawnPosAtControl = gm.hero_ctrl.transform.position;
-            gm.StartCoroutine(SpawnShadeAfterDelay(spawnPosAtControl, 0.5f));
+            SpawnShadeAtPosition(spawnPosAtControl);
         }
         catch { }
     }
 
-    private static IEnumerator SpawnShadeAfterDelay(Vector3 pos, float delay)
+    private static void SpawnShadeAtPosition(Vector3 pos)
     {
-        yield return new WaitForSeconds(delay);
         var gm = GameManager.instance;
-        if (gm == null || gm.hero_ctrl == null) yield break;
+        if (gm == null || gm.hero_ctrl == null) return;
 
         if (helper != null)
         {
@@ -119,6 +119,7 @@ public partial class LegacyHelper : BaseUnityPlugin
                 if (sc != null)
                 {
                     sc.TeleportToPosition(pos);
+                    sc.TriggerSpawnEntrance();
                     SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
                 }
                 else
@@ -127,7 +128,7 @@ public partial class LegacyHelper : BaseUnityPlugin
                 }
             }
             catch { }
-            yield break;
+            return;
         }
 
         // Create fresh helper at the captured position
@@ -150,6 +151,8 @@ public partial class LegacyHelper : BaseUnityPlugin
             sr.sortingLayerID = hornetRenderer.sortingLayerID;
             sr.sortingOrder = hornetRenderer.sortingOrder + 1;
         }
+
+        scNew.TriggerSpawnEntrance();
     }
 
     internal static void DisableStartup(GameManager gm)

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -242,11 +242,13 @@ public partial class LegacyHelper
                 var tr = __instance.transform;
                 var scale = tr.localScale;
                 string parent = tr.parent ? tr.parent.name : "(null)";
-                UnityEngine.Debug.Log($"[ShadeDebug] NailSlash spawned: {__instance.name} scale={scale} parent={parent}\n{System.Environment.StackTrace}");
+                if (ModConfig.Instance.logShade)
+                    UnityEngine.Debug.Log($"[ShadeDebug] NailSlash spawned: {__instance.name} scale={scale} parent={parent}\n{System.Environment.StackTrace}");
             }
             catch (System.Exception ex)
             {
-                UnityEngine.Debug.Log($"[ShadeDebug] NailSlash log error: {ex}");
+                if (ModConfig.Instance.logShade)
+                    UnityEngine.Debug.Log($"[ShadeDebug] NailSlash log error: {ex}");
             }
         }
     }

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -77,6 +77,9 @@ public partial class LegacyHelper
         private Sprite[] currentAnimFrames;
         private int animFrameIndex;
         private float animTimer;
+        private Coroutine spawnRoutine;
+        private bool pendingSpawnAnimation;
+        private bool isSpawning;
         private const float AnimFrameTime = 0.1f;
         private Vector2 lastMoveDelta;
         private Renderer[] shadeLightRenderers;
@@ -95,7 +98,33 @@ public partial class LegacyHelper
         private const KeyCode SprintKeyPrimary = KeyCode.LeftShift;
         private const KeyCode SprintKeySecondary = KeyCode.RightShift;
         private const KeyCode DamageToggleKey = KeyCode.Alpha0;
+
+        private struct AxisLeashLimits
+        {
+            public float NegativeSoft;
+            public float PositiveSoft;
+            public float NegativeHard;
+            public float PositiveHard;
+            public float NegativeSnap;
+            public float PositiveSnap;
+        }
+
+        private struct DynamicLeashLimits
+        {
+            public AxisLeashLimits X;
+            public AxisLeashLimits Y;
+        }
+
+        private const float LeashScreenPadding = 0.75f;
+        private const float SoftLimitRatio = 0.9f;
+        private const float SnapExtraMultiplier = 1.2f;
+        private const float SnapExtraMin = 0.75f;
+        private const float SnapMinWhenNoRoom = 0.25f;
+
         private bool canTakeDamage = true;
+        private Vector2 capturedMoveInput;
+        private float capturedHorizontalInput;
+        private bool capturedSprintHeld;
         // Spells use FireKey + W (Shriek) or FireKey + S (Descending Dark)
 
         // Teleport channel
@@ -262,6 +291,7 @@ public partial class LegacyHelper
             lastSavedHP = lastSavedMax = lastSavedSoul = -999;
             PersistIfChanged();
             lastSoulForReady = shadeSoul;
+            TryPlaySpawnAnimation();
         }
 
         private void LoadShadeSprites()
@@ -324,6 +354,76 @@ public partial class LegacyHelper
             return sprites;
         }
 
+        public void TriggerSpawnEntrance()
+        {
+            pendingSpawnAnimation = true;
+            TryPlaySpawnAnimation();
+        }
+
+        private void TryPlaySpawnAnimation()
+        {
+            if (!pendingSpawnAnimation)
+                return;
+            if (!isActiveAndEnabled)
+                return;
+            if (!sr)
+                sr = GetComponent<SpriteRenderer>();
+            if (sr == null)
+                return;
+            if (deathAnimFrames == null || deathAnimFrames.Length == 0)
+                return;
+
+            StopSpawnAnimation();
+            spawnRoutine = StartCoroutine(SpawnAppearanceRoutine());
+            pendingSpawnAnimation = false;
+        }
+
+        private void StopSpawnAnimation()
+        {
+            if (spawnRoutine != null)
+            {
+                StopCoroutine(spawnRoutine);
+                spawnRoutine = null;
+            }
+            isSpawning = false;
+            pendingSpawnAnimation = false;
+        }
+
+        private IEnumerator SpawnAppearanceRoutine()
+        {
+            isSpawning = true;
+            var frames = deathAnimFrames;
+            if (frames != null && frames.Length > 0)
+            {
+                float perFrame = 0.5f / frames.Length;
+                for (int i = frames.Length - 1; i >= 0; i--)
+                {
+                    if (sr != null)
+                        sr.sprite = frames[i];
+                    yield return new WaitForSeconds(perFrame);
+                }
+            }
+            else
+            {
+                yield return null;
+            }
+            spawnRoutine = null;
+            isSpawning = false;
+            currentAnimFrames = null;
+            if (sr != null)
+            {
+                var c = sr.color;
+                c.a = 0.9f;
+                sr.color = c;
+                if (idleAnimFrames != null && idleAnimFrames.Length > 0)
+                {
+                    sr.sprite = idleAnimFrames[0];
+                    animFrameIndex = 0;
+                    animTimer = 0f;
+                }
+            }
+        }
+
         private static bool TryLoadImage(Texture2D tex, byte[] bytes)
         {
             try
@@ -358,6 +458,9 @@ public partial class LegacyHelper
         {
             if (sr == null) return;
             sr.flipX = (facing == 1);
+
+            if (isSpawning)
+                return;
 
             if (isCastingSpell && currentAnimFrames != null)
                 return;
@@ -457,7 +560,10 @@ public partial class LegacyHelper
             if (Input.GetKeyDown(DamageToggleKey))
             {
                 canTakeDamage = !canTakeDamage;
-                try { UnityEngine.Debug.Log($"[ShadeDebug] Damage {(canTakeDamage ? "enabled" : "disabled")}"); } catch { }
+                if (ModConfig.Instance.logShade)
+                {
+                    try { UnityEngine.Debug.Log($"[ShadeDebug] Damage {(canTakeDamage ? "enabled" : "disabled")}"); } catch { }
+                }
                 PersistIfChanged();
             }
             ignoreRefreshTimer -= Time.deltaTime;
@@ -488,9 +594,20 @@ public partial class LegacyHelper
             CheckSprintUnlock();
             AdjustLeashForCamera();
 
-            HandleMovementAndFacing();
+            bool inputLocked = ShouldBlockInput();
+
+            if (inputLocked)
+            {
+                capturedMoveInput = Vector2.zero;
+                capturedHorizontalInput = 0f;
+                capturedSprintHeld = false;
+            }
+            else
+            {
+                CaptureMovementInput();
+            }
             // Allow starting focus even when not casting other spells; focusing itself sets isCastingSpell
-            if (!inHardLeash && !isChannelingTeleport && !isInactive)
+            if (!inHardLeash && !isChannelingTeleport && !isInactive && !inputLocked)
             {
                 HandleFocus();
                 if (!isCastingSpell)
@@ -510,6 +627,17 @@ public partial class LegacyHelper
             PersistIfChanged();
             CheckFocusReadySfx();
             HandleAnimation();
+        }
+
+        private void FixedUpdate()
+        {
+            if (hornetTransform == null) return;
+            if (ShouldBlockInput())
+            {
+                if (rb) rb.linearVelocity = Vector2.zero;
+                return;
+            }
+            HandleMovementAndFacing(Time.fixedDeltaTime);
         }
 
         public void ApplyBindHealFromHornet(Transform hornet)
@@ -563,7 +691,185 @@ public partial class LegacyHelper
             }
         }
 
-        private void HandleMovementAndFacing()
+        private bool ShouldBlockInput()
+        {
+            try
+            {
+                var gm = GameManager.instance;
+                if (gm != null && gm.IsGamePaused())
+                    return true;
+            }
+            catch { }
+
+            return Time.timeScale <= 0f;
+        }
+
+        private void CaptureMovementInput()
+        {
+            float h = (Input.GetKey(KeyCode.A) ? -1f : 0f) + (Input.GetKey(KeyCode.D) ? 1f : 0f);
+            float v = (Input.GetKey(KeyCode.S) ? -1f : 0f) + (Input.GetKey(KeyCode.W) ? 1f : 0f);
+            Vector2 input = new Vector2(h, v);
+            if (input.sqrMagnitude > 1f) input.Normalize();
+            if (isChannelingTeleport)
+                input = Vector2.zero;
+            capturedMoveInput = input;
+            capturedHorizontalInput = h;
+            capturedSprintHeld = sprintUnlocked &&
+                                 (Input.GetKey(SprintKeyPrimary) || Input.GetKey(SprintKeySecondary)) &&
+                                 input.sqrMagnitude > 0f;
+        }
+
+        private DynamicLeashLimits GetDynamicLeashLimits(Vector3 hornetWorld)
+        {
+            var limits = new DynamicLeashLimits
+            {
+                X = new AxisLeashLimits
+                {
+                    NegativeSoft = softLeashRadius,
+                    PositiveSoft = softLeashRadius,
+                    NegativeHard = hardLeashRadius,
+                    PositiveHard = hardLeashRadius,
+                    NegativeSnap = snapLeashRadius,
+                    PositiveSnap = snapLeashRadius
+                },
+                Y = new AxisLeashLimits
+                {
+                    NegativeSoft = softLeashRadius,
+                    PositiveSoft = softLeashRadius,
+                    NegativeHard = hardLeashRadius,
+                    PositiveHard = hardLeashRadius,
+                    NegativeSnap = snapLeashRadius,
+                    PositiveSnap = snapLeashRadius
+                }
+            };
+
+            try
+            {
+                var gm = GameManager.instance;
+                var camCtrl = gm != null ? gm.cameraCtrl : null;
+                var cam = camCtrl != null ? camCtrl.cam : null;
+                if (cam != null)
+                {
+                    Vector3 viewport = cam.WorldToViewportPoint(hornetWorld);
+                    float depth = viewport.z;
+                    if (depth > 0f)
+                    {
+                        Vector3 leftWorld = cam.ViewportToWorldPoint(new Vector3(0f, viewport.y, depth));
+                        Vector3 rightWorld = cam.ViewportToWorldPoint(new Vector3(1f, viewport.y, depth));
+                        Vector3 bottomWorld = cam.ViewportToWorldPoint(new Vector3(viewport.x, 0f, depth));
+                        Vector3 topWorld = cam.ViewportToWorldPoint(new Vector3(viewport.x, 1f, depth));
+
+                        float leftRoom = Mathf.Max(0f, hornetWorld.x - leftWorld.x - LeashScreenPadding);
+                        float rightRoom = Mathf.Max(0f, rightWorld.x - hornetWorld.x - LeashScreenPadding);
+                        float downRoom = Mathf.Max(0f, hornetWorld.y - bottomWorld.y - LeashScreenPadding);
+                        float upRoom = Mathf.Max(0f, topWorld.y - hornetWorld.y - LeashScreenPadding);
+
+                        ApplyAxisLimit(ref limits.X.NegativeSoft, ref limits.X.NegativeHard, ref limits.X.NegativeSnap, leftRoom);
+                        ApplyAxisLimit(ref limits.X.PositiveSoft, ref limits.X.PositiveHard, ref limits.X.PositiveSnap, rightRoom);
+                        ApplyAxisLimit(ref limits.Y.NegativeSoft, ref limits.Y.NegativeHard, ref limits.Y.NegativeSnap, downRoom);
+                        ApplyAxisLimit(ref limits.Y.PositiveSoft, ref limits.Y.PositiveHard, ref limits.Y.PositiveSnap, upRoom);
+                    }
+                }
+            }
+            catch { }
+
+            return limits;
+        }
+
+        private float GetRadialHardLimit(DynamicLeashLimits limits)
+        {
+            float axisMax = Mathf.Max(
+                Mathf.Max(limits.X.NegativeHard, limits.X.PositiveHard),
+                Mathf.Max(limits.Y.NegativeHard, limits.Y.PositiveHard));
+            return Mathf.Max(maxDistance, axisMax);
+        }
+
+        private float GetRadialSnapLimit(DynamicLeashLimits limits)
+        {
+            float axisMax = Mathf.Max(
+                Mathf.Max(limits.X.NegativeSnap, limits.X.PositiveSnap),
+                Mathf.Max(limits.Y.NegativeSnap, limits.Y.PositiveSnap));
+            return Mathf.Max(snapLeashRadius, axisMax);
+        }
+
+        private static void ApplyAxisLimit(ref float soft, ref float hard, ref float snap, float available)
+        {
+            soft = Mathf.Max(0f, soft);
+            hard = Mathf.Max(0f, hard);
+            snap = Mathf.Max(0f, snap);
+
+            if (available <= 0f)
+            {
+                soft = 0f;
+                hard = Mathf.Min(hard, 0f);
+                snap = Mathf.Max(hard, Mathf.Min(snap, SnapMinWhenNoRoom));
+                return;
+            }
+
+            float clampedHard = Mathf.Max(0f, available);
+            hard = clampedHard;
+            float desiredSoft = Mathf.Clamp(clampedHard * SoftLimitRatio, 0f, clampedHard);
+            soft = desiredSoft;
+            float desiredSnap = Mathf.Max(clampedHard * SnapExtraMultiplier, clampedHard + SnapExtraMin);
+            snap = Mathf.Max(clampedHard, Mathf.Max(snap, desiredSnap));
+        }
+
+        private static bool BeyondAxis(float value, float negativeLimit, float positiveLimit)
+        {
+            if (value > 0f)
+                return positiveLimit >= 0f && value > positiveLimit;
+            if (value < 0f)
+                return negativeLimit >= 0f && -value > negativeLimit;
+            return false;
+        }
+
+        private static bool BeyondSnap(float value, float negativeSnap, float positiveSnap)
+        {
+            if (value > 0f)
+                return positiveSnap >= 0f && value > positiveSnap;
+            if (value < 0f)
+                return negativeSnap >= 0f && -value > negativeSnap;
+            return false;
+        }
+
+        private static float ComputeAxisRatio(float value, float negativeSoft, float positiveSoft, float negativeHard, float positiveHard)
+        {
+            if (value > 0f)
+            {
+                float soft = Mathf.Max(0f, positiveSoft);
+                if (value <= soft)
+                    return 0f;
+                float hard = Mathf.Max(soft, positiveHard);
+                if (hard <= soft + Mathf.Epsilon)
+                    return 1f;
+                float clamped = Mathf.Min(value, hard);
+                return (clamped - soft) / Mathf.Max(0.0001f, hard - soft);
+            }
+            if (value < 0f)
+            {
+                float abs = -value;
+                float soft = Mathf.Max(0f, negativeSoft);
+                if (abs <= soft)
+                    return 0f;
+                float hard = Mathf.Max(soft, negativeHard);
+                if (hard <= soft + Mathf.Epsilon)
+                    return 1f;
+                float clamped = Mathf.Min(abs, hard);
+                return (clamped - soft) / Mathf.Max(0.0001f, hard - soft);
+            }
+            return 0f;
+        }
+
+        private static float ClampAxis(float value, float negativeLimit, float positiveLimit)
+        {
+            float min = negativeLimit > 0f ? -negativeLimit : 0f;
+            float max = positiveLimit > 0f ? positiveLimit : 0f;
+            if (negativeLimit <= 0f && positiveLimit <= 0f)
+                return 0f;
+            return Mathf.Clamp(value, min, max);
+        }
+
+        private void HandleMovementAndFacing(float deltaTime)
         {
             if (isCastingSpell || isFocusing)
             {
@@ -575,18 +881,23 @@ public partial class LegacyHelper
                 hardLeashTimer = 0f;
                 return;
             }
-            float h = (Input.GetKey(KeyCode.A) ? -1f : 0f) + (Input.GetKey(KeyCode.D) ? 1f : 0f);
-            float v = (Input.GetKey(KeyCode.S) ? -1f : 0f) + (Input.GetKey(KeyCode.W) ? 1f : 0f);
-            Vector2 input = new Vector2(h, v);
-            if (input.sqrMagnitude > 1f) input.Normalize();
+            Vector2 input = capturedMoveInput;
+            float h = capturedHorizontalInput;
 
-            // Freeze manual input while channeling teleport
-            if (isChannelingTeleport) input = Vector2.zero;
+            Vector3 hornetWorld = hornetTransform.position;
+            Vector2 hornetPos2D = new Vector2(hornetWorld.x, hornetWorld.y);
+            Vector2 currentPos = rb ? rb.position : (Vector2)transform.position;
+            Vector2 offsetFromHornet = currentPos - hornetPos2D;
+            Vector2 toHornet = -offsetFromHornet;
+            float dist = toHornet.magnitude;
 
-            Vector2 to = (Vector2)(hornetTransform.position - transform.position);
-            float dist = to.magnitude;
+            var leash = GetDynamicLeashLimits(hornetWorld);
+            float radialHardLimit = GetRadialHardLimit(leash);
+            float radialSnapLimit = GetRadialSnapLimit(leash);
 
-            if (dist > snapLeashRadius)
+            if (BeyondSnap(offsetFromHornet.x, leash.X.NegativeSnap, leash.X.PositiveSnap) ||
+                BeyondSnap(offsetFromHornet.y, leash.Y.NegativeSnap, leash.Y.PositiveSnap) ||
+                dist > radialSnapLimit)
             {
                 TeleportToHornet();
                 inHardLeash = false; hardLeashTimer = 0f; EnableCollisions(true);
@@ -594,21 +905,15 @@ public partial class LegacyHelper
             }
 
             Vector2 moveDelta = Vector2.zero;
-            if (dist > softLeashRadius && dist <= hardLeashRadius)
-            {
-                float t = Mathf.InverseLerp(softLeashRadius, hardLeashRadius, dist);
-                Vector2 pullDir = to.normalized;
-                moveDelta += pullDir * (Mathf.Lerp(softPullSpeed, softPullSpeed * 1.5f, t)) * Time.deltaTime;
-                inHardLeash = false; hardLeashTimer = 0f; EnableCollisions(true);
-            }
 
-            if (dist > hardLeashRadius)
+            if (BeyondAxis(offsetFromHornet.x, leash.X.NegativeHard, leash.X.PositiveHard) ||
+                BeyondAxis(offsetFromHornet.y, leash.Y.NegativeHard, leash.Y.PositiveHard))
             {
                 inHardLeash = true;
-                hardLeashTimer += Time.deltaTime;
+                hardLeashTimer += deltaTime;
                 EnableCollisions(false);
-                Vector2 dir = to.normalized;
-                moveDelta = dir * hardPullSpeed * Time.deltaTime;
+                Vector2 dir = toHornet.sqrMagnitude > 0.0001f ? toHornet.normalized : Vector2.zero;
+                moveDelta = dir * hardPullSpeed * deltaTime;
                 if (hardLeashTimer >= hardLeashTimeout)
                 {
                     TeleportToHornet();
@@ -616,17 +921,29 @@ public partial class LegacyHelper
                     return;
                 }
             }
-            else if (inHardLeash)
+            else
             {
-                inHardLeash = false; hardLeashTimer = 0f; EnableCollisions(true);
+                if (inHardLeash)
+                {
+                    inHardLeash = false;
+                    hardLeashTimer = 0f;
+                    EnableCollisions(true);
+                }
+
+                float ratioX = ComputeAxisRatio(offsetFromHornet.x, leash.X.NegativeSoft, leash.X.PositiveSoft, leash.X.NegativeHard, leash.X.PositiveHard);
+                float ratioY = ComputeAxisRatio(offsetFromHornet.y, leash.Y.NegativeSoft, leash.Y.PositiveSoft, leash.Y.NegativeHard, leash.Y.PositiveHard);
+                float pullStrength = Mathf.Max(ratioX, ratioY);
+                if (pullStrength > 0f)
+                {
+                    Vector2 dir = toHornet.sqrMagnitude > 0.0001f ? toHornet.normalized : Vector2.zero;
+                    moveDelta += dir * Mathf.Lerp(softPullSpeed, softPullSpeed * 1.5f, pullStrength) * deltaTime;
+                }
             }
 
             if (!inHardLeash)
             {
                 float speed = moveSpeed;
-                bool sprinting = sprintUnlocked &&
-                                 (Input.GetKey(SprintKeyPrimary) || Input.GetKey(SprintKeySecondary)) &&
-                                 input.sqrMagnitude > 0f;
+                bool sprinting = capturedSprintHeld && input.sqrMagnitude > 0f;
                 bool startedSprint = sprinting && !isSprinting;
                 if (startedSprint)
                 {
@@ -641,7 +958,7 @@ public partial class LegacyHelper
                 if (sprintDashTimer > 0f)
                 {
                     speed *= sprintDashMultiplier;
-                    sprintDashTimer -= Time.deltaTime;
+                    sprintDashTimer -= deltaTime;
                     if (activeDashPs)
                     {
                         var emit = new ParticleSystem.EmitParams();
@@ -659,9 +976,9 @@ public partial class LegacyHelper
                     }
                 }
                 if (sprintDashCooldownTimer > 0f)
-                    sprintDashCooldownTimer -= Time.deltaTime;
+                    sprintDashCooldownTimer -= deltaTime;
 
-                moveDelta += input * speed * Time.deltaTime;
+                moveDelta += input * speed * deltaTime;
                 isSprinting = sprinting;
             }
             else
@@ -672,32 +989,38 @@ public partial class LegacyHelper
 
             if (knockbackTimer > 0f)
             {
-                moveDelta += knockbackVelocity * Time.deltaTime;
-                knockbackVelocity = Vector2.Lerp(knockbackVelocity, Vector2.zero, 10f * Time.deltaTime);
-                knockbackTimer -= Time.deltaTime;
+                moveDelta += knockbackVelocity * deltaTime;
+                knockbackVelocity = Vector2.Lerp(knockbackVelocity, Vector2.zero, 10f * deltaTime);
+                knockbackTimer -= deltaTime;
             }
 
-            // Compute proposed next position and clamp against transition gates at map edges
-            Vector2 curPos = rb ? rb.position : (Vector2)transform.position;
-            Vector2 proposed = curPos + moveDelta;
+            Vector2 proposed = currentPos + moveDelta;
             proposed = ClampAgainstTransitionGates(proposed);
 
-            if (rb) rb.MovePosition(proposed);
-            else transform.position = proposed;
-            lastMoveDelta = proposed - curPos;
+            Vector2 proposedOffset = proposed - hornetPos2D;
+            proposedOffset.x = ClampAxis(proposedOffset.x, leash.X.NegativeHard, leash.X.PositiveHard);
+            proposedOffset.y = ClampAxis(proposedOffset.y, leash.Y.NegativeHard, leash.Y.PositiveHard);
+            Vector2 clampedPos = hornetPos2D + proposedOffset;
 
-            // Update facing only from player's horizontal input.
-            // Do not auto-face Hornet when idle; preserve last manual facing.
+            Vector2 finalToHornet = hornetPos2D - clampedPos;
+            float finalDist = finalToHornet.magnitude;
+            if (finalDist > radialHardLimit && finalDist > 0f)
+            {
+                clampedPos = hornetPos2D - finalToHornet.normalized * radialHardLimit;
+                Vector2 clampedOffset = clampedPos - hornetPos2D;
+                clampedOffset.x = ClampAxis(clampedOffset.x, leash.X.NegativeHard, leash.X.PositiveHard);
+                clampedOffset.y = ClampAxis(clampedOffset.y, leash.Y.NegativeHard, leash.Y.PositiveHard);
+                clampedPos = hornetPos2D + clampedOffset;
+            }
+
+            if (rb) rb.MovePosition(clampedPos);
+            else transform.position = clampedPos;
+            lastMoveDelta = clampedPos - currentPos;
+
             if (h > 0.1f) facing = 1;
             else if (h < -0.1f) facing = -1;
 
             if (sr != null) sr.flipX = (facing == 1);
-
-            if (dist > maxDistance)
-            {
-                Vector3 toShade = transform.position - hornetTransform.position;
-                transform.position = hornetTransform.position + toShade.normalized * maxDistance;
-            }
         }
 
         private void CheckSprintUnlock()
@@ -1149,7 +1472,8 @@ public partial class LegacyHelper
                 try { if (h.collider.GetComponentInParent<DamageHero>() != null) continue; } catch { }
                 // otherwise this is acceptable ground
                 pick = h;
-                UnityEngine.Debug.Log($"[ShadeDebug] Descending Dark ground hit {h.collider.name} tag={h.collider.tag} layer={h.collider.gameObject.layer}");
+                if (ModConfig.Instance.logShade)
+                    UnityEngine.Debug.Log($"[ShadeDebug] Descending Dark ground hit {h.collider.name} tag={h.collider.tag} layer={h.collider.gameObject.layer}");
                 break;
             }
 
@@ -1745,6 +2069,7 @@ public partial class LegacyHelper
         private void StartDeathAnimation()
         {
             if (isDying) return;
+            StopSpawnAnimation();
             if (deathRoutine != null) StopCoroutine(deathRoutine);
             isDying = true;
             deathRoutine = StartCoroutine(DeathAnimationRoutine());

--- a/LegacyHelper.ShadeController.Slash.cs
+++ b/LegacyHelper.ShadeController.Slash.cs
@@ -135,7 +135,8 @@ public partial class LegacyHelper
                     }
                 }
                 catch { }
-                UnityEngine.Debug.Log($"[ShadeDebug] Shade slash spawned: {slash.name} scale={ls} parent={tr.parent?.name}\n{System.Environment.StackTrace}");
+                if (ModConfig.Instance.logShade)
+                    UnityEngine.Debug.Log($"[ShadeDebug] Shade slash spawned: {slash.name} scale={ls} parent={tr.parent?.name}\n{System.Environment.StackTrace}");
             }
             catch { }
 

--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -12,6 +12,10 @@ internal static class ModPaths
 public class ModConfig
 {
     public bool logDamage = true;
+    public bool logGeneral = true;
+    public bool logMenu = true;
+    public bool logShade = true;
+    public bool logHud = true;
     public float hornetDamageMultiplier = 1f;
     public float shadeDamageMultiplier = 1f;
     public int bindHornetHeal = 3;

--- a/ShadeSettingsMenu.cs
+++ b/ShadeSettingsMenu.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
@@ -14,36 +15,205 @@ public static class ShadeSettingsMenu
     private static GameObject screen;
     private static bool built;
     private static UIManager builtFor;
-    private static MenuSelectable firstSelectable;
+    private static MenuScreen mainScreen;
+    private static MenuScreen difficultyScreen;
+    private static MenuScreen controlsScreen;
+    private static MenuScreen loggingScreen;
+    private static MenuScreen activeScreen;
+    private static readonly List<MenuScreen> allScreens = new();
+    private static readonly Dictionary<MenuScreen, MenuSelectable> screenFirstSelectables = new();
+    private static GameObject templateSource;
+    private static bool templateSourceWasActive;
     private static readonly ManualLogSource log = BepInEx.Logging.Logger.CreateLogSource("ShadeSettingsMenu");
     private static bool loggedBuildAttempt;
     private static bool loggedMissingOptionsMenu;
     private static bool loggedMissingSliderTemplate;
-    private static bool loggedMissingToggleTemplate;
     private static bool loggedNullUI;
     private static bool loggedNoPauseMenu;
     private static bool loggedButtonAlreadyPresent;
     private static bool loggedNoPauseButtonTemplates;
     private static bool loggedNoMenuButtonList;
     private static bool loggedNullEntries;
+    private const float FractionalSliderStep = 0.1f;
 
-    private class CancelToPause : MonoBehaviour, ICancelHandler
+    private struct ShadowStyle
     {
+        public Type Type;
+        public Color EffectColor;
+        public Vector2 EffectDistance;
+        public bool UseGraphicAlpha;
+    }
+
+    private struct TextStyle
+    {
+        public Font Font;
+        public int FontSize;
+        public FontStyle FontStyle;
+        public TextAnchor Alignment;
+        public Color Color;
+        public bool RichText;
+        public bool BestFit;
+        public int BestFitMin;
+        public int BestFitMax;
+        public float LineSpacing;
+        public bool AlignByGeometry;
+        public HorizontalWrapMode HorizontalOverflow;
+        public VerticalWrapMode VerticalOverflow;
+        public List<ShadowStyle> Shadows;
+    }
+
+    private static TextStyle? sliderLabelStyle;
+    private static TextStyle? sliderValueStyle;
+    private static TextStyle? toggleLabelStyle;
+    private static Font fallbackFont;
+    private static Sprite fallbackSlicedSprite;
+    private static Sprite fallbackKnobSprite;
+    private static Sprite fallbackCheckSprite;
+
+    private static void LogMenu(LogLevel level, string message)
+    {
+        if (!ModConfig.Instance.logMenu)
+            return;
+        log.Log(level, message);
+    }
+
+    private static void LogMenuDebug(string message) => LogMenu(LogLevel.Debug, message);
+    private static void LogMenuInfo(string message) => LogMenu(LogLevel.Info, message);
+    private static void LogMenuWarning(string message) => LogMenu(LogLevel.Warning, message);
+    private static void LogMenuError(string message) => LogMenu(LogLevel.Error, message);
+
+    private enum CancelTarget
+    {
+        PauseMenu,
+        ShadeMain
+    }
+
+    private class CancelRouter : MonoBehaviour, ICancelHandler
+    {
+        public CancelTarget target;
+
         public void OnCancel(BaseEventData eventData)
         {
-            if (builtFor != null)
+            eventData?.Use();
+            if (target == CancelTarget.ShadeMain)
+            {
+                ShowMainMenu();
+            }
+            else if (builtFor != null)
+            {
                 HideImmediate(builtFor);
+            }
         }
     }
 
-    private static IEnumerator FocusSelectableNextFrame(Selectable target, MenuSelectable wrapper)
+    internal static bool IsShowing => activeScreen != null && activeScreen.gameObject != null && activeScreen.gameObject.activeSelf;
+
+    private sealed class SliderMenuDriver : MonoBehaviour, IMoveHandler, ISubmitHandler
     {
-        yield return null;
-        EventSystem.current.SetSelectedGameObject(target.gameObject);
-        target.navigation = wrapper.navigation;
+        public Slider slider;
+        public bool wholeNumbers;
+
+        public void Initialize(Slider s, bool whole)
+        {
+            slider = s;
+            wholeNumbers = whole;
+        }
+
+        private void Step(float direction)
+        {
+            if (slider == null)
+                return;
+            float delta = wholeNumbers ? 1f : FractionalSliderStep;
+            float target = slider.value + delta * direction;
+            float snapped = SnapSliderValue(target, slider.minValue, slider.maxValue, wholeNumbers);
+            if (!Mathf.Approximately(snapped, slider.value))
+            {
+                slider.value = snapped;
+            }
+        }
+
+        public void OnMove(AxisEventData eventData)
+        {
+            if (slider == null || eventData == null)
+                return;
+            if (eventData.moveDir == MoveDirection.Left)
+            {
+                Step(-1f);
+                eventData.Use();
+            }
+            else if (eventData.moveDir == MoveDirection.Right)
+            {
+                Step(1f);
+                eventData.Use();
+            }
+        }
+
+        public void OnSubmit(BaseEventData eventData)
+        {
+            if (slider == null)
+                return;
+            Step(1f);
+            eventData?.Use();
+        }
     }
 
-    internal static bool IsShowing => screen != null && screen.activeSelf;
+    private sealed class ToggleMenuDriver : MonoBehaviour, IMoveHandler, ISubmitHandler
+    {
+        public Toggle toggle;
+
+        public void Initialize(Toggle t)
+        {
+            toggle = t;
+        }
+
+        public void OnMove(AxisEventData eventData)
+        {
+            if (toggle == null || eventData == null)
+                return;
+            if (eventData.moveDir == MoveDirection.Left)
+            {
+                if (toggle.isOn)
+                    toggle.isOn = false;
+                eventData.Use();
+            }
+            else if (eventData.moveDir == MoveDirection.Right)
+            {
+                if (!toggle.isOn)
+                    toggle.isOn = true;
+                eventData.Use();
+            }
+        }
+
+        public void OnSubmit(BaseEventData eventData)
+        {
+            if (toggle == null)
+                return;
+            toggle.isOn = !toggle.isOn;
+            eventData?.Use();
+        }
+    }
+
+    private static Sprite GetFallbackSprite(ref Sprite cache, string spriteName, bool sliced)
+    {
+        if (cache != null)
+            return cache;
+
+        const int size = 16;
+        var tex = new Texture2D(size, size, TextureFormat.RGBA32, false);
+        var colors = new Color32[size * size];
+        for (int i = 0; i < colors.Length; i++)
+            colors[i] = new Color32(255, 255, 255, 255);
+        tex.SetPixels32(colors);
+        tex.Apply();
+        tex.name = spriteName + "Tex";
+        tex.hideFlags = HideFlags.HideAndDontSave;
+
+        Vector4 border = sliced ? new Vector4(6f, 6f, 6f, 6f) : Vector4.zero;
+        cache = Sprite.Create(tex, new Rect(0f, 0f, size, size), new Vector2(0.5f, 0.5f), size, 0, SpriteMeshType.FullRect, border);
+        cache.name = spriteName;
+        cache.hideFlags = HideFlags.HideAndDontSave;
+        return cache;
+    }
 
     private static MenuSelectable CreateDefaultSliderTemplate()
     {
@@ -60,7 +230,15 @@ public static class ShadeSettingsMenu
         var background = new GameObject("Background");
         background.transform.SetParent(sliderGo.transform, false);
         var bgImage = background.AddComponent<Image>();
-        bgImage.color = Color.white;
+        var uiSprite = GetFallbackSprite(ref fallbackSlicedSprite, "ShadeSettingsSliderBg", true);
+        bgImage.sprite = uiSprite;
+        bgImage.type = Image.Type.Sliced;
+        bgImage.color = new Color(0.12f, 0.12f, 0.12f, 0.9f);
+        var backgroundRt = background.GetComponent<RectTransform>();
+        backgroundRt.anchorMin = Vector2.zero;
+        backgroundRt.anchorMax = Vector2.one;
+        backgroundRt.offsetMin = Vector2.zero;
+        backgroundRt.offsetMax = Vector2.zero;
 
         var fillArea = new GameObject("Fill Area");
         fillArea.transform.SetParent(sliderGo.transform, false);
@@ -72,6 +250,14 @@ public static class ShadeSettingsMenu
         var fill = new GameObject("Fill");
         fill.transform.SetParent(fillArea.transform, false);
         var fillImg = fill.AddComponent<Image>();
+        fillImg.sprite = uiSprite;
+        fillImg.type = Image.Type.Sliced;
+        fillImg.color = new Color(0.75f, 0.75f, 0.78f, 0.95f);
+        var fillRt = fill.GetComponent<RectTransform>();
+        fillRt.anchorMin = new Vector2(0f, 0f);
+        fillRt.anchorMax = new Vector2(1f, 1f);
+        fillRt.offsetMin = Vector2.zero;
+        fillRt.offsetMax = Vector2.zero;
 
         var handleArea = new GameObject("Handle Slide Area");
         handleArea.transform.SetParent(sliderGo.transform, false);
@@ -83,12 +269,25 @@ public static class ShadeSettingsMenu
         var handle = new GameObject("Handle");
         handle.transform.SetParent(handleArea.transform, false);
         var handleImg = handle.AddComponent<Image>();
+        var knobSprite = GetFallbackSprite(ref fallbackKnobSprite, "ShadeSettingsSliderKnob", false);
+        handleImg.sprite = knobSprite;
+        handleImg.color = Color.white;
+        var handleRt = handle.GetComponent<RectTransform>();
+        handleRt.sizeDelta = new Vector2(20f, 20f);
 
         var slider = sliderGo.AddComponent<Slider>();
         slider.fillRect = fill.GetComponent<RectTransform>();
         slider.handleRect = handle.GetComponent<RectTransform>();
         slider.targetGraphic = handleImg;
         slider.direction = Slider.Direction.LeftToRight;
+        slider.transition = Selectable.Transition.ColorTint;
+        var colors = slider.colors;
+        colors.normalColor = Color.white;
+        colors.highlightedColor = new Color(1f, 0.95f, 0.78f, 1f);
+        colors.pressedColor = new Color(0.85f, 0.85f, 0.85f, 1f);
+        colors.selectedColor = colors.normalColor;
+        colors.disabledColor = new Color(0.2f, 0.2f, 0.2f, 0.6f);
+        slider.colors = colors;
 
         root.SetActive(false);
         return selectable;
@@ -109,20 +308,207 @@ public static class ShadeSettingsMenu
         var background = new GameObject("Background");
         background.transform.SetParent(toggleGo.transform, false);
         var bgImage = background.AddComponent<Image>();
+        var uiSprite = GetFallbackSprite(ref fallbackSlicedSprite, "ShadeSettingsToggleBg", true);
+        bgImage.sprite = uiSprite;
+        bgImage.type = Image.Type.Sliced;
+        bgImage.color = new Color(0.12f, 0.12f, 0.12f, 0.9f);
+        var backgroundRt = background.GetComponent<RectTransform>();
+        backgroundRt.anchorMin = Vector2.zero;
+        backgroundRt.anchorMax = Vector2.one;
+        backgroundRt.offsetMin = Vector2.zero;
+        backgroundRt.offsetMax = Vector2.zero;
 
         var checkmark = new GameObject("Checkmark");
         checkmark.transform.SetParent(background.transform, false);
         var checkImg = checkmark.AddComponent<Image>();
+        var checkSprite = GetFallbackSprite(ref fallbackCheckSprite, "ShadeSettingsToggleCheck", false);
+        checkImg.sprite = checkSprite;
+        checkImg.color = new Color(0.9f, 0.9f, 0.9f, 1f);
+        var checkRt = checkmark.GetComponent<RectTransform>();
+        checkRt.anchorMin = new Vector2(0.2f, 0.2f);
+        checkRt.anchorMax = new Vector2(0.8f, 0.8f);
+        checkRt.offsetMin = Vector2.zero;
+        checkRt.offsetMax = Vector2.zero;
 
         var toggle = toggleGo.AddComponent<Toggle>();
         toggle.graphic = checkImg;
         toggle.targetGraphic = bgImage;
+        toggle.transition = Selectable.Transition.ColorTint;
+        var colors = toggle.colors;
+        colors.normalColor = Color.white;
+        colors.highlightedColor = new Color(1f, 0.95f, 0.78f, 1f);
+        colors.pressedColor = new Color(0.85f, 0.85f, 0.85f, 1f);
+        colors.selectedColor = colors.normalColor;
+        colors.disabledColor = new Color(0.2f, 0.2f, 0.2f, 0.6f);
+        toggle.colors = colors;
 
         root.SetActive(false);
         return selectable;
     }
 
-    private static MenuSelectable CreateSlider(Transform parent, MenuSelectable template, string label, float min, float max, float value, System.Action<float> onChange, bool whole = false)
+    private static List<ShadowStyle> CaptureShadowStyles(Graphic graphic)
+    {
+        var list = new List<ShadowStyle>();
+        foreach (var shadow in graphic.GetComponents<Shadow>())
+        {
+            list.Add(new ShadowStyle
+            {
+                Type = shadow.GetType(),
+                EffectColor = shadow.effectColor,
+                EffectDistance = shadow.effectDistance,
+                UseGraphicAlpha = shadow.useGraphicAlpha
+            });
+        }
+        return list;
+    }
+
+    private static TextStyle CaptureTextStyle(Text text)
+    {
+        return new TextStyle
+        {
+            Font = text.font,
+            FontSize = text.fontSize,
+            FontStyle = text.fontStyle,
+            Alignment = text.alignment,
+            Color = text.color,
+            RichText = text.supportRichText,
+            BestFit = text.resizeTextForBestFit,
+            BestFitMin = text.resizeTextMinSize,
+            BestFitMax = text.resizeTextMaxSize,
+            LineSpacing = text.lineSpacing,
+            AlignByGeometry = text.alignByGeometry,
+            HorizontalOverflow = text.horizontalOverflow,
+            VerticalOverflow = text.verticalOverflow,
+            Shadows = CaptureShadowStyles(text)
+        };
+    }
+
+    private static void ClearAndApplyShadows(Graphic graphic, List<ShadowStyle> styles)
+    {
+        foreach (var shadow in graphic.GetComponents<Shadow>())
+            Object.DestroyImmediate(shadow);
+
+        if (styles == null)
+            return;
+
+        foreach (var style in styles)
+        {
+            if (style.Type == null)
+                continue;
+            if (!(graphic.gameObject.AddComponent(style.Type) is Shadow newShadow))
+                continue;
+            newShadow.effectColor = style.EffectColor;
+            newShadow.effectDistance = style.EffectDistance;
+            newShadow.useGraphicAlpha = style.UseGraphicAlpha;
+        }
+    }
+
+    private static void ApplyTextStyle(Text text, TextStyle? style, TextAnchor defaultAlignment, Color defaultColor)
+    {
+        var resolved = style.GetValueOrDefault();
+        bool hasStyle = style.HasValue;
+
+        var fontToUse = resolved.Font != null ? resolved.Font : fallbackFont;
+        if (fontToUse == null)
+            fontToUse = Resources.GetBuiltinResource<Font>("Arial.ttf");
+
+        text.font = fontToUse;
+        text.color = hasStyle ? resolved.Color : defaultColor;
+        text.alignment = hasStyle ? resolved.Alignment : defaultAlignment;
+        text.fontSize = hasStyle && resolved.FontSize > 0 ? resolved.FontSize : 24;
+        text.fontStyle = hasStyle ? resolved.FontStyle : FontStyle.Normal;
+        text.supportRichText = hasStyle ? resolved.RichText : true;
+        text.lineSpacing = hasStyle ? resolved.LineSpacing : 1f;
+        text.resizeTextForBestFit = hasStyle && resolved.BestFit;
+        text.resizeTextMinSize = hasStyle && resolved.BestFit ? resolved.BestFitMin : 10;
+        text.resizeTextMaxSize = hasStyle && resolved.BestFit ? resolved.BestFitMax : 40;
+        text.alignByGeometry = hasStyle ? resolved.AlignByGeometry : false;
+        text.horizontalOverflow = hasStyle ? resolved.HorizontalOverflow : HorizontalWrapMode.Overflow;
+        text.verticalOverflow = hasStyle ? resolved.VerticalOverflow : VerticalWrapMode.Overflow;
+
+        ClearAndApplyShadows(text, hasStyle ? resolved.Shadows : null);
+    }
+
+    private static void CacheTextStyles(MenuSelectable sliderTemplate, MenuSelectable toggleTemplate)
+    {
+        sliderLabelStyle = null;
+        sliderValueStyle = null;
+        toggleLabelStyle = null;
+        fallbackFont = null;
+
+        if (sliderTemplate != null)
+        {
+            foreach (var text in sliderTemplate.GetComponentsInChildren<Text>(true))
+            {
+                if (text == null)
+                    continue;
+                var hasAuto = text.GetComponent<AutoLocalizeTextUI>() != null;
+                if (hasAuto)
+                {
+                    if (!sliderLabelStyle.HasValue)
+                    {
+                        sliderLabelStyle = CaptureTextStyle(text);
+                        if (text.font != null)
+                            fallbackFont ??= text.font;
+                    }
+                }
+                else
+                {
+                    if (!sliderValueStyle.HasValue)
+                    {
+                        sliderValueStyle = CaptureTextStyle(text);
+                        if (text.font != null)
+                            fallbackFont ??= text.font;
+                    }
+                }
+            }
+        }
+
+        if (toggleTemplate != null)
+        {
+            foreach (var text in toggleTemplate.GetComponentsInChildren<Text>(true))
+            {
+                if (text == null)
+                    continue;
+                if (!toggleLabelStyle.HasValue)
+                {
+                    toggleLabelStyle = CaptureTextStyle(text);
+                    if (text.font != null)
+                        fallbackFont ??= text.font;
+                }
+            }
+        }
+
+        if (fallbackFont == null)
+            fallbackFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+    }
+
+    private static float SnapSliderValue(float value, float min, float max, bool whole)
+    {
+        value = Mathf.Clamp(value, min, max);
+        if (whole)
+        {
+            var rounded = Mathf.Round(value);
+            if (rounded < min)
+                rounded = min;
+            if (rounded > max)
+                rounded = max;
+            return rounded;
+        }
+
+        float snapped = Mathf.Round((value - min) / FractionalSliderStep) * FractionalSliderStep + min;
+        snapped = Mathf.Clamp(snapped, min, max);
+        float multiplier = 1f / FractionalSliderStep;
+        snapped = Mathf.Round(snapped * multiplier) / multiplier;
+        return snapped;
+    }
+
+    private static string FormatSliderValue(float value, bool whole)
+    {
+        return whole ? Mathf.RoundToInt(value).ToString() : value.ToString("0.0", CultureInfo.InvariantCulture);
+    }
+
+    private static MenuSelectable CreateSlider(Transform parent, MenuSelectable template, string label, float min, float max, float value, System.Action<float> onChange, CancelTarget cancelTarget, bool whole = false)
     {
         // container row stretching full width
         var row = new GameObject(label + "Row");
@@ -136,20 +522,18 @@ public static class ShadeSettingsMenu
         hLayout.childControlWidth = true;
         hLayout.childForceExpandHeight = false;
         hLayout.childForceExpandWidth = false;
-        hLayout.spacing = 40f;
+        hLayout.spacing = 36f;
         hLayout.childAlignment = TextAnchor.MiddleLeft;
 
         // label text
         var labelObj = new GameObject("Label");
         labelObj.transform.SetParent(row.transform, false);
         var labelTxt = labelObj.AddComponent<Text>();
-        labelTxt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        ApplyTextStyle(labelTxt, sliderLabelStyle, TextAnchor.MiddleLeft, Color.white);
         labelTxt.text = label;
-        labelTxt.color = Color.white;
-        labelTxt.alignment = TextAnchor.MiddleLeft;
         var labelLe = labelObj.AddComponent<LayoutElement>();
-        labelLe.minWidth = 300f;
-        labelLe.preferredWidth = 300f;
+        labelLe.minWidth = 340f;
+        labelLe.preferredWidth = 340f;
 
         // slider instance
         var go = Object.Instantiate(template.gameObject, row.transform, false);
@@ -164,6 +548,8 @@ public static class ShadeSettingsMenu
             foreach (var tmp in tmps)
                 Object.DestroyImmediate(tmp);
         }
+        foreach (var auto in go.GetComponentsInChildren<AutoLocalizeTextUI>(true))
+            Object.DestroyImmediate(auto);
 
         var slider = go.GetComponentInChildren<Slider>(true);
         Object.DestroyImmediate(slider.GetComponent<MenuAudioSlider>());
@@ -188,23 +574,40 @@ public static class ShadeSettingsMenu
         var valueObj = new GameObject("Value");
         valueObj.transform.SetParent(row.transform, false);
         var valueTxt = valueObj.AddComponent<Text>();
-        valueTxt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
-        valueTxt.color = Color.white;
-        valueTxt.alignment = TextAnchor.MiddleRight;
+        ApplyTextStyle(valueTxt, sliderValueStyle, TextAnchor.MiddleRight, Color.white);
         var valueLe = valueObj.AddComponent<LayoutElement>();
-        valueLe.minWidth = 80f;
-        valueLe.preferredWidth = 80f;
+        valueLe.minWidth = 110f;
+        valueLe.preferredWidth = 110f;
 
         slider.minValue = min;
         slider.maxValue = max;
         slider.wholeNumbers = whole;
-        slider.SetValueWithoutNotify(value);
-        valueTxt.text = whole ? Mathf.RoundToInt(value).ToString() : value.ToString("0.00");
+        float initialValue = SnapSliderValue(value, min, max, whole);
+        slider.SetValueWithoutNotify(initialValue);
+        valueTxt.text = FormatSliderValue(initialValue, whole);
+        if (!Mathf.Approximately(initialValue, value))
+        {
+            try
+            {
+                onChange.Invoke(initialValue);
+            }
+            catch (Exception e)
+            {
+                LogMenuWarning($"Error normalizing slider '{label}' value: {e}");
+            }
+        }
         slider.onValueChanged.AddListener(v =>
         {
-            onChange.Invoke(v);
-            valueTxt.text = whole ? Mathf.RoundToInt(v).ToString() : v.ToString("0.00");
+            var snapped = SnapSliderValue(v, min, max, whole);
+            if (!Mathf.Approximately(snapped, v))
+                slider.SetValueWithoutNotify(snapped);
+            onChange.Invoke(snapped);
+            valueTxt.text = FormatSliderValue(snapped, whole);
         });
+
+        var nav = slider.navigation;
+        nav.mode = Navigation.Mode.Explicit;
+        slider.navigation = nav;
 
         var rowLe = row.AddComponent<LayoutElement>();
         rowLe.preferredHeight = rect.sizeDelta.y;
@@ -214,21 +617,20 @@ public static class ShadeSettingsMenu
         var selectable = go.GetComponent<MenuSelectable>();
         if (selectable == null)
         {
-            log.LogError($"Created slider '{label}' missing Selectable component");
+            LogMenuError($"Created slider '{label}' missing Selectable component");
             Object.Destroy(row);
             return null;
         }
         selectable.DontPlaySelectSound = true;
-        selectable.cancelAction = CancelAction.GoToPauseMenu;
-        slider.gameObject.AddComponent<CancelToPause>();
-        selectable.OnSelected += _ =>
-        {
-            selectable.StartCoroutine(FocusSelectableNextFrame(slider, selectable));
-        };
+        selectable.cancelAction = CancelAction.DoNothing;
+        var router = go.GetComponent<CancelRouter>() ?? go.AddComponent<CancelRouter>();
+        router.target = cancelTarget;
+        var driver = go.GetComponent<SliderMenuDriver>() ?? go.AddComponent<SliderMenuDriver>();
+        driver.Initialize(slider, whole);
         return selectable;
     }
 
-    private static MenuSelectable CreateToggle(Transform parent, MenuSelectable template, string label, bool value, System.Action<bool> onChange)
+    private static MenuSelectable CreateToggle(Transform parent, MenuSelectable template, string label, bool value, System.Action<bool> onChange, CancelTarget cancelTarget)
     {
         // container row stretching full width
         var row = new GameObject(label + "Row");
@@ -242,20 +644,18 @@ public static class ShadeSettingsMenu
         hLayout.childControlWidth = true;
         hLayout.childForceExpandHeight = false;
         hLayout.childForceExpandWidth = false;
-        hLayout.spacing = 40f;
+        hLayout.spacing = 36f;
         hLayout.childAlignment = TextAnchor.MiddleLeft;
 
         // label text
         var labelObj = new GameObject("Label");
         labelObj.transform.SetParent(row.transform, false);
         var labelTxt = labelObj.AddComponent<Text>();
-        labelTxt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        ApplyTextStyle(labelTxt, toggleLabelStyle, TextAnchor.MiddleLeft, Color.white);
         labelTxt.text = label;
-        labelTxt.color = Color.white;
-        labelTxt.alignment = TextAnchor.MiddleLeft;
         var labelLe = labelObj.AddComponent<LayoutElement>();
-        labelLe.minWidth = 300f;
-        labelLe.preferredWidth = 300f;
+        labelLe.minWidth = 340f;
+        labelLe.preferredWidth = 340f;
 
         // toggle instance
         var go = Object.Instantiate(template.gameObject, row.transform, false);
@@ -270,6 +670,8 @@ public static class ShadeSettingsMenu
             foreach (var tmp in tmps)
                 Object.DestroyImmediate(tmp);
         }
+        foreach (var auto in go.GetComponentsInChildren<AutoLocalizeTextUI>(true))
+            Object.DestroyImmediate(auto);
 
         var toggle = go.GetComponentInChildren<Toggle>(true);
         Object.DestroyImmediate(toggle.GetComponent<MenuPreventDeselect>());
@@ -279,13 +681,17 @@ public static class ShadeSettingsMenu
         rect.pivot = new Vector2(0f, 0.5f);
         var toggleLe = go.GetComponent<LayoutElement>() ?? go.AddComponent<LayoutElement>();
         toggleLe.minWidth = 60f;
+        toggleLe.preferredWidth = 60f;
 
         toggle.onValueChanged.RemoveAllListeners();
         toggle.isOn = value;
         toggle.interactable = true;
         toggle.enabled = true;
         toggle.onValueChanged.AddListener(onChange.Invoke);
-        toggle.gameObject.AddComponent<CancelToPause>();
+
+        var toggleNav = toggle.navigation;
+        toggleNav.mode = Navigation.Mode.Explicit;
+        toggle.navigation = toggleNav;
 
         var rowLe = row.AddComponent<LayoutElement>();
         rowLe.preferredHeight = rect.sizeDelta.y;
@@ -294,64 +700,493 @@ public static class ShadeSettingsMenu
         var selectable = go.GetComponent<MenuSelectable>();
         if (selectable == null)
         {
-            log.LogError($"Created toggle '{label}' missing Selectable component");
+            LogMenuError($"Created toggle '{label}' missing Selectable component");
             Object.Destroy(row);
             return null;
         }
         selectable.DontPlaySelectSound = true;
-        selectable.cancelAction = CancelAction.GoToPauseMenu;
-        selectable.OnSelected += _ =>
-        {
-            selectable.StartCoroutine(FocusSelectableNextFrame(toggle, selectable));
-        };
+        selectable.cancelAction = CancelAction.DoNothing;
+        var router = go.GetComponent<CancelRouter>() ?? go.AddComponent<CancelRouter>();
+        router.target = cancelTarget;
+        var driver = go.GetComponent<ToggleMenuDriver>() ?? go.AddComponent<ToggleMenuDriver>();
+        driver.Initialize(toggle);
         return selectable;
+    }
+
+    private static void DestroyScreens()
+    {
+        foreach (var ms in allScreens)
+        {
+            if (ms != null)
+                Object.Destroy(ms.gameObject);
+        }
+        allScreens.Clear();
+        screenFirstSelectables.Clear();
+        mainScreen = null;
+        difficultyScreen = null;
+        controlsScreen = null;
+        loggingScreen = null;
+        activeScreen = null;
+        screen = null;
+        templateSource = null;
+        templateSourceWasActive = false;
+    }
+
+    private static void StripMenuScreen(MenuScreen ms)
+    {
+        if (ms == null)
+            return;
+
+        foreach (var behaviour in ms.GetComponents<MonoBehaviour>())
+        {
+            if (behaviour == null || behaviour is MenuScreen)
+                continue;
+            Object.DestroyImmediate(behaviour);
+        }
+
+        ms.defaultHighlight = null;
+
+        if (ms.backButton != null)
+        {
+            foreach (var cond in ms.backButton.GetComponents<MenuButtonListCondition>())
+                Object.DestroyImmediate(cond);
+            foreach (var auto in ms.backButton.GetComponentsInChildren<AutoLocalizeTextUI>(true))
+                Object.DestroyImmediate(auto);
+            ms.backButton.OnSubmitPressed.RemoveAllListeners();
+            ms.backButton.DontPlaySelectSound = true;
+            ms.backButton.gameObject.SetActive(true);
+        }
+    }
+
+    private static void InitializeScreen(MenuScreen ms)
+    {
+        if (ms == null)
+            return;
+        var canvasGroup = ms.ScreenCanvasGroup;
+        if (canvasGroup != null)
+        {
+            canvasGroup.alpha = 1f;
+            canvasGroup.interactable = true;
+            canvasGroup.blocksRaycasts = true;
+        }
+        var rt = ms.GetComponent<RectTransform>();
+        if (rt != null)
+        {
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+        }
+        ms.transform.SetAsLastSibling();
+    }
+
+    private static RectTransform CreateContentRoot(MenuScreen ms)
+    {
+        if (ms == null)
+            return null;
+        var toDestroy = new List<GameObject>();
+        foreach (Transform child in ms.transform)
+        {
+            if (ms.backButton != null && child.gameObject == ms.backButton.gameObject)
+                continue;
+            toDestroy.Add(child.gameObject);
+        }
+
+        foreach (var go in toDestroy)
+        {
+            if (go != null)
+                Object.DestroyImmediate(go);
+        }
+
+        var content = new GameObject("Content");
+        var contentRect = content.AddComponent<RectTransform>();
+        contentRect.SetParent(ms.transform, false);
+        contentRect.anchorMin = new Vector2(0f, 0f);
+        contentRect.anchorMax = new Vector2(1f, 1f);
+        contentRect.pivot = new Vector2(0.5f, 1f);
+        contentRect.anchoredPosition = Vector2.zero;
+        contentRect.offsetMin = new Vector2(60f, 80f);
+        contentRect.offsetMax = new Vector2(-60f, -140f);
+        var layout = content.AddComponent<VerticalLayoutGroup>();
+        layout.childControlHeight = true;
+        layout.childControlWidth = true;
+        layout.childForceExpandHeight = false;
+        layout.childForceExpandWidth = true;
+        layout.spacing = 24f;
+        layout.padding = new RectOffset(0, 0, 0, 0);
+        layout.childAlignment = TextAnchor.UpperLeft;
+        return contentRect;
+    }
+
+    private static void ConfigureBackButton(MenuScreen ms, CancelTarget cancelTarget, UIManager ui)
+    {
+        if (ms?.backButton == null)
+            return;
+        ms.backButton.OnSubmitPressed.RemoveAllListeners();
+        if (cancelTarget == CancelTarget.PauseMenu)
+        {
+            if (ui != null)
+                ms.backButton.OnSubmitPressed.AddListener(() => ui.StartCoroutine(Hide(ui)));
+        }
+        else
+        {
+            ms.backButton.OnSubmitPressed.AddListener(ShowMainMenu);
+        }
+        ms.backButton.cancelAction = CancelAction.DoNothing;
+        var router = ms.backButton.gameObject.GetComponent<CancelRouter>() ?? ms.backButton.gameObject.AddComponent<CancelRouter>();
+        router.target = cancelTarget;
+    }
+
+    private static void SetupButtonList(MenuScreen ms, List<MenuSelectable> selectables)
+    {
+        if (ms == null)
+            return;
+        var mbl = ms.GetComponent<MenuButtonList>() ?? ms.gameObject.AddComponent<MenuButtonList>();
+        mbl.ClearLastSelected();
+        var entryField = typeof(MenuButtonList).GetField("entries", BindingFlags.NonPublic | BindingFlags.Instance);
+        if (entryField == null)
+        {
+            LogMenuWarning("MenuButtonList entries field null");
+            return;
+        }
+        var entryType = entryField.FieldType.GetElementType();
+        if (entryType == null)
+        {
+            LogMenuWarning("MenuButtonList entry type null");
+            return;
+        }
+        var arr = Array.CreateInstance(entryType, selectables.Count);
+        for (int i = 0; i < selectables.Count; i++)
+        {
+            var e = Activator.CreateInstance(entryType);
+            entryType.GetField("selectable", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(e, selectables[i]);
+            arr.SetValue(e, i);
+        }
+        entryField.SetValue(mbl, arr);
+        mbl.SetupActive();
+    }
+
+    private static MenuSelectable GetPreferredHighlight(MenuScreen ms)
+    {
+        if (ms == null)
+            return null;
+        if (screenFirstSelectables.TryGetValue(ms, out var selectable) && selectable != null)
+            return selectable;
+        if (ms.backButton != null)
+            return ms.backButton;
+        return null;
+    }
+
+    private static MenuSelectable CreateMenuButton(Transform parent, MenuButton template, string label, System.Action onSubmit, CancelTarget cancelTarget)
+    {
+        if (template == null)
+            return null;
+        var go = Object.Instantiate(template.gameObject, parent, false);
+        go.SetActive(true);
+        go.name = label.Replace(" ", string.Empty) + "Button";
+        foreach (var auto in go.GetComponentsInChildren<AutoLocalizeTextUI>(true))
+            Object.DestroyImmediate(auto);
+        bool hasLabel = false;
+        var text = go.GetComponentInChildren<Text>(true);
+        if (text != null)
+        {
+            text.text = label;
+            text.color = Color.white;
+            hasLabel = true;
+        }
+        else
+        {
+            var tmpType = Type.GetType("TMPro.TextMeshProUGUI, Unity.TextMeshPro");
+            if (tmpType != null)
+            {
+                var tmp = go.GetComponentInChildren(tmpType, true);
+                if (tmp != null)
+                {
+                    tmpType.GetProperty("text")?.SetValue(tmp, label);
+                    tmpType.GetProperty("color")?.SetValue(tmp, Color.white);
+                    hasLabel = true;
+                }
+            }
+        }
+        if (!hasLabel)
+        {
+            var labelObj = new GameObject("Label");
+            labelObj.transform.SetParent(go.transform, false);
+            var fallback = labelObj.AddComponent<Text>();
+            ApplyTextStyle(fallback, sliderLabelStyle, TextAnchor.MiddleCenter, Color.white);
+            fallback.text = label;
+        }
+        foreach (var cond in go.GetComponents<MenuButtonListCondition>())
+            Object.DestroyImmediate(cond);
+        var btn = go.GetComponent<MenuButton>();
+        if (btn == null)
+        {
+            Object.Destroy(go);
+            return null;
+        }
+        btn.OnSubmitPressed.RemoveAllListeners();
+        if (onSubmit != null)
+            btn.OnSubmitPressed.AddListener(() => onSubmit());
+        btn.cancelAction = CancelAction.DoNothing;
+        var router = go.GetComponent<CancelRouter>() ?? go.AddComponent<CancelRouter>();
+        router.target = cancelTarget;
+        btn.DontPlaySelectSound = true;
+        return btn;
+    }
+
+    private static MenuButton CreateDefaultMenuButtonTemplate()
+    {
+        var root = new GameObject("DefaultMenuButton");
+        root.hideFlags = HideFlags.HideAndDontSave;
+        var rt = root.AddComponent<RectTransform>();
+        rt.sizeDelta = new Vector2(420f, 60f);
+        var image = root.AddComponent<Image>();
+        var sprite = GetFallbackSprite(ref fallbackSlicedSprite, "ShadeSettingsButtonBg", true);
+        image.sprite = sprite;
+        image.type = Image.Type.Sliced;
+        image.color = new Color(0.12f, 0.12f, 0.12f, 0.9f);
+        var button = root.AddComponent<MenuButton>();
+        button.transition = Selectable.Transition.ColorTint;
+        var colors = button.colors;
+        colors.normalColor = Color.white;
+        colors.highlightedColor = new Color(1f, 0.95f, 0.78f, 1f);
+        colors.pressedColor = new Color(0.85f, 0.85f, 0.85f, 1f);
+        colors.selectedColor = colors.normalColor;
+        colors.disabledColor = new Color(0.2f, 0.2f, 0.2f, 0.6f);
+        button.colors = colors;
+        var layout = root.AddComponent<LayoutElement>();
+        layout.minHeight = 60f;
+        layout.preferredHeight = 60f;
+        layout.minWidth = 420f;
+        layout.preferredWidth = 420f;
+        var labelObj = new GameObject("Label");
+        labelObj.transform.SetParent(root.transform, false);
+        var text = labelObj.AddComponent<Text>();
+        ApplyTextStyle(text, sliderLabelStyle, TextAnchor.MiddleCenter, Color.white);
+        text.text = "Button";
+        root.SetActive(false);
+        return button;
+    }
+
+    private static void BuildMainMenu(UIManager ui, MenuScreen ms, MenuButton buttonTemplate)
+    {
+        if (ms == null)
+            return;
+        var content = CreateContentRoot(ms);
+        if (content == null)
+            return;
+        var selectables = new List<MenuSelectable>();
+        if (difficultyScreen != null)
+        {
+            var s = CreateMenuButton(content, buttonTemplate, "Difficulty", () => ShowScreen(difficultyScreen), CancelTarget.PauseMenu);
+            if (s != null) selectables.Add(s);
+        }
+        if (controlsScreen != null)
+        {
+            var s = CreateMenuButton(content, buttonTemplate, "Controls", () => ShowScreen(controlsScreen), CancelTarget.PauseMenu);
+            if (s != null) selectables.Add(s);
+        }
+        if (loggingScreen != null)
+        {
+            var s = CreateMenuButton(content, buttonTemplate, "Logging", () => ShowScreen(loggingScreen), CancelTarget.PauseMenu);
+            if (s != null) selectables.Add(s);
+        }
+        SetupButtonList(ms, selectables);
+        if (selectables.Count > 0)
+        {
+            var first = selectables[0];
+            screenFirstSelectables[ms] = first;
+            ms.defaultHighlight = first;
+        }
+        else if (ms.backButton != null)
+        {
+            screenFirstSelectables[ms] = ms.backButton;
+            ms.defaultHighlight = ms.backButton;
+        }
+        ConfigureBackButton(ms, CancelTarget.PauseMenu, ui);
+        LayoutRebuilder.ForceRebuildLayoutImmediate(content);
+    }
+
+    private static void BuildDifficultyMenu(UIManager ui, MenuScreen ms, MenuSelectable sliderTemplate)
+    {
+        if (ms == null || sliderTemplate == null)
+            return;
+        var content = CreateContentRoot(ms);
+        if (content == null)
+            return;
+        var selectables = new List<MenuSelectable>();
+        void AddSlider(string label, float min, float max, float value, System.Action<float> onChange, bool whole = false)
+        {
+            var s = CreateSlider(content, sliderTemplate, label, min, max, value, onChange, CancelTarget.ShadeMain, whole);
+            if (s != null) selectables.Add(s);
+        }
+        AddSlider("Hornet Damage", 0.2f, 2f, ModConfig.Instance.hornetDamageMultiplier, v => ModConfig.Instance.hornetDamageMultiplier = v);
+        AddSlider("Shade Damage", 0.2f, 2f, ModConfig.Instance.shadeDamageMultiplier, v => ModConfig.Instance.shadeDamageMultiplier = v);
+        AddSlider("Shade Heal (Bind)", 0f, 6f, ModConfig.Instance.bindShadeHeal, v => ModConfig.Instance.bindShadeHeal = Mathf.RoundToInt(v), true);
+        AddSlider("Hornet Heal (Bind)", 0f, 6f, ModConfig.Instance.bindHornetHeal, v => ModConfig.Instance.bindHornetHeal = Mathf.RoundToInt(v), true);
+        AddSlider("Shade Focus Heal", 0f, 6f, ModConfig.Instance.focusShadeHeal, v => ModConfig.Instance.focusShadeHeal = Mathf.RoundToInt(v), true);
+        AddSlider("Hornet Focus Heal", 0f, 6f, ModConfig.Instance.focusHornetHeal, v => ModConfig.Instance.focusHornetHeal = Mathf.RoundToInt(v), true);
+        SetupButtonList(ms, selectables);
+        if (selectables.Count > 0)
+        {
+            var first = selectables[0];
+            screenFirstSelectables[ms] = first;
+            ms.defaultHighlight = first;
+        }
+        else if (ms.backButton != null)
+        {
+            screenFirstSelectables[ms] = ms.backButton;
+            ms.defaultHighlight = ms.backButton;
+        }
+        ConfigureBackButton(ms, CancelTarget.ShadeMain, ui);
+        LayoutRebuilder.ForceRebuildLayoutImmediate(content);
+    }
+
+    private static void BuildControlsMenu(UIManager ui, MenuScreen ms)
+    {
+        if (ms == null)
+            return;
+        var content = CreateContentRoot(ms);
+        if (content == null)
+            return;
+        var info = new GameObject("ControlsInfo");
+        info.transform.SetParent(content, false);
+        var text = info.AddComponent<Text>();
+        ApplyTextStyle(text, sliderLabelStyle, TextAnchor.MiddleCenter, Color.white);
+        text.text = "Controller configuration options will appear here in a future update.";
+        var layout = info.AddComponent<LayoutElement>();
+        layout.preferredHeight = 40f;
+        SetupButtonList(ms, new List<MenuSelectable>());
+        if (ms.backButton != null)
+        {
+            screenFirstSelectables[ms] = ms.backButton;
+            ms.defaultHighlight = ms.backButton;
+        }
+        ConfigureBackButton(ms, CancelTarget.ShadeMain, ui);
+        LayoutRebuilder.ForceRebuildLayoutImmediate(content);
+    }
+
+    private static void BuildLoggingMenu(UIManager ui, MenuScreen ms, MenuSelectable toggleTemplate)
+    {
+        if (ms == null || toggleTemplate == null)
+            return;
+        var content = CreateContentRoot(ms);
+        if (content == null)
+            return;
+        var selectables = new List<MenuSelectable>();
+        void AddToggle(string label, bool value, System.Action<bool> onChange)
+        {
+            var t = CreateToggle(content, toggleTemplate, label, value, onChange, CancelTarget.ShadeMain);
+            if (t != null) selectables.Add(t);
+        }
+        AddToggle("General Logs", ModConfig.Instance.logGeneral, v => ModConfig.Instance.logGeneral = v);
+        AddToggle("Menu Logs", ModConfig.Instance.logMenu, v => ModConfig.Instance.logMenu = v);
+        AddToggle("Shade Debug Logs", ModConfig.Instance.logShade, v => ModConfig.Instance.logShade = v);
+        AddToggle("HUD Debug Logs", ModConfig.Instance.logHud, v => ModConfig.Instance.logHud = v);
+        AddToggle("Damage Summary File", ModConfig.Instance.logDamage, v => ModConfig.Instance.logDamage = v);
+        SetupButtonList(ms, selectables);
+        if (selectables.Count > 0)
+        {
+            var first = selectables[0];
+            screenFirstSelectables[ms] = first;
+            ms.defaultHighlight = first;
+        }
+        else if (ms.backButton != null)
+        {
+            screenFirstSelectables[ms] = ms.backButton;
+            ms.defaultHighlight = ms.backButton;
+        }
+        ConfigureBackButton(ms, CancelTarget.ShadeMain, ui);
+        LayoutRebuilder.ForceRebuildLayoutImmediate(content);
+    }
+
+    private static void ShowScreen(MenuScreen target)
+    {
+        if (target == null)
+            return;
+        target.transform.SetAsLastSibling();
+        foreach (var ms in allScreens)
+        {
+            if (ms == null)
+                continue;
+            bool show = ms == target;
+            ms.gameObject.SetActive(show);
+        }
+        activeScreen = target;
+        var highlight = GetPreferredHighlight(target);
+        if (highlight != null)
+        {
+            if (EventSystem.current != null)
+                EventSystem.current.SetSelectedGameObject(highlight.gameObject);
+            UIManager.HighlightSelectableNoSound(highlight.GetFirstInteractable());
+        }
+    }
+
+    private static void ShowMainMenu()
+    {
+        ShowScreen(mainScreen);
     }
 
     private static void Build(UIManager ui)
     {
         if (!loggedBuildAttempt)
         {
-            log.LogInfo("Attempting to build Shade settings page");
+            LogMenuInfo("Attempting to build Shade settings page");
             loggedBuildAttempt = true;
         }
-        if (built && screen != null && builtFor == ui)
+        if (built && mainScreen != null && builtFor == ui)
         {
-            log.LogDebug("Settings page already built for this UI");
+            LogMenuDebug("Settings page already built for this UI");
             return;
         }
 
-        if (screen != null && builtFor != ui)
+        if ((mainScreen != null || allScreens.Count > 0) && builtFor != ui)
         {
-            log.LogDebug("UIManager changed, destroying previous settings page");
-            Object.Destroy(screen);
-            screen = null;
+            LogMenuDebug("UIManager changed, destroying previous settings page");
+            DestroyScreens();
         }
 
         built = false;
         builtFor = ui;
+        screenFirstSelectables.Clear();
+        allScreens.Clear();
+        activeScreen = null;
 
-        // Need an options menu screen to clone for consistent styling
         var optionsScreen = ui.optionsMenuScreen;
         GameObject templateScreen;
+        templateSource = optionsScreen != null ? optionsScreen.gameObject : null;
+        templateSourceWasActive = templateSource != null && templateSource.activeSelf;
         if (optionsScreen == null)
         {
             if (!loggedMissingOptionsMenu)
             {
-                log.LogWarning("optionsMenuScreen not yet available; using pause menu as template");
+                LogMenuWarning("optionsMenuScreen not yet available; using pause menu as template");
                 loggedMissingOptionsMenu = true;
             }
-            templateScreen = ui.pauseMenuScreen.gameObject;
+            templateScreen = ui.pauseMenuScreen != null ? ui.pauseMenuScreen.gameObject : null;
+            if (templateScreen == null)
+            {
+                templateSource = null;
+                templateSourceWasActive = false;
+            }
         }
         else
         {
             templateScreen = optionsScreen.gameObject;
         }
 
+        if (templateScreen == null)
+        {
+            LogMenuWarning("Template screen not available; aborting build");
+            return;
+        }
+
         MenuSelectable sliderTemplate = null;
         if (optionsScreen != null)
         {
-            var candidates = optionsScreen.GetComponentsInChildren<MenuSelectable>(true);
-            foreach (var cand in candidates)
+            foreach (var cand in optionsScreen.GetComponentsInChildren<MenuSelectable>(true))
             {
                 if (cand.GetComponentInChildren<Slider>(true) != null)
                 {
@@ -365,7 +1200,7 @@ public static class ShadeSettingsMenu
         {
             if (!loggedMissingSliderTemplate)
             {
-                log.LogWarning("slider template not found in options menu; using default");
+                LogMenuWarning("slider template not found in options menu; using default");
                 loggedMissingSliderTemplate = true;
             }
             sliderTemplate = CreateDefaultSliderTemplate();
@@ -375,8 +1210,7 @@ public static class ShadeSettingsMenu
         MenuSelectable toggleTemplate = null;
         if (optionsScreen != null)
         {
-            var candidates = optionsScreen.GetComponentsInChildren<MenuSelectable>(true);
-            foreach (var cand in candidates)
+            foreach (var cand in optionsScreen.GetComponentsInChildren<MenuSelectable>(true))
             {
                 if (cand.GetComponentInChildren<Toggle>(true) != null)
                 {
@@ -388,112 +1222,99 @@ public static class ShadeSettingsMenu
         bool createdToggleTemplate = false;
         if (toggleTemplate == null)
         {
-            if (!loggedMissingToggleTemplate)
-            {
-                log.LogWarning("toggle template not found in options menu; using default");
-                loggedMissingToggleTemplate = true;
-            }
             toggleTemplate = CreateDefaultToggleTemplate();
             createdToggleTemplate = true;
         }
 
-        screen = Object.Instantiate(templateScreen, templateScreen.transform.parent);
-        screen.name = "ShadeSettingsPage";
-        screen.SetActive(false);
-        log.LogDebug("Instantiated ShadeSettingsPage");
+        CacheTextStyles(sliderTemplate, toggleTemplate);
 
-        var canvasGroup = screen.GetComponent<CanvasGroup>();
-        if (canvasGroup != null)
+        MenuButton buttonTemplate = null;
+        bool createdButtonTemplate = false;
+        if (optionsScreen != null)
         {
-            canvasGroup.alpha = 1f;
-            canvasGroup.interactable = true;
-            canvasGroup.blocksRaycasts = true;
+            foreach (var cand in optionsScreen.GetComponentsInChildren<MenuButton>(true))
+            {
+                if (optionsScreen.backButton != null && cand == optionsScreen.backButton)
+                    continue;
+                buttonTemplate = Object.Instantiate(cand.gameObject).GetComponent<MenuButton>();
+                createdButtonTemplate = true;
+                break;
+            }
+        }
+        if (buttonTemplate == null)
+        {
+            var templateMenuScreen = templateScreen.GetComponent<MenuScreen>();
+            if (templateMenuScreen != null && templateMenuScreen.backButton != null)
+            {
+                buttonTemplate = Object.Instantiate(templateMenuScreen.backButton.gameObject).GetComponent<MenuButton>();
+                createdButtonTemplate = true;
+            }
+        }
+        if (buttonTemplate == null)
+        {
+            buttonTemplate = CreateDefaultMenuButtonTemplate();
+            createdButtonTemplate = true;
+        }
+        if (buttonTemplate != null)
+        {
+            buttonTemplate.gameObject.hideFlags = HideFlags.HideAndDontSave;
+            buttonTemplate.gameObject.SetActive(false);
         }
 
-        var rt = screen.GetComponent<RectTransform>();
-        rt.anchorMin = Vector2.zero;
-        rt.anchorMax = Vector2.one;
-        rt.pivot = new Vector2(0.5f, 0.5f);
-        rt.anchoredPosition = Vector2.zero;
-        rt.offsetMin = Vector2.zero;
-        rt.offsetMax = Vector2.zero;
+        mainScreen = Object.Instantiate(templateScreen, templateScreen.transform.parent).GetComponent<MenuScreen>();
+        StripMenuScreen(mainScreen);
+        difficultyScreen = Object.Instantiate(templateScreen, templateScreen.transform.parent).GetComponent<MenuScreen>();
+        StripMenuScreen(difficultyScreen);
+        controlsScreen = Object.Instantiate(templateScreen, templateScreen.transform.parent).GetComponent<MenuScreen>();
+        StripMenuScreen(controlsScreen);
+        loggingScreen = Object.Instantiate(templateScreen, templateScreen.transform.parent).GetComponent<MenuScreen>();
+        StripMenuScreen(loggingScreen);
 
-        var ms = screen.GetComponent<MenuScreen>();
-
-        // remove existing children except back button
-        foreach (Transform child in ms.transform)
+        if (mainScreen != null)
         {
-            if (ms.backButton != null && child.gameObject == ms.backButton.gameObject)
-                continue;
-            Object.Destroy(child.gameObject);
+            mainScreen.gameObject.name = "ShadeSettingsMain";
+            mainScreen.gameObject.SetActive(false);
+            InitializeScreen(mainScreen);
+            allScreens.Add(mainScreen);
+        }
+        if (difficultyScreen != null)
+        {
+            difficultyScreen.gameObject.name = "ShadeSettingsDifficulty";
+            difficultyScreen.gameObject.SetActive(false);
+            InitializeScreen(difficultyScreen);
+            allScreens.Add(difficultyScreen);
+        }
+        if (controlsScreen != null)
+        {
+            controlsScreen.gameObject.name = "ShadeSettingsControls";
+            controlsScreen.gameObject.SetActive(false);
+            InitializeScreen(controlsScreen);
+            allScreens.Add(controlsScreen);
+        }
+        if (loggingScreen != null)
+        {
+            loggingScreen.gameObject.name = "ShadeSettingsLogging";
+            loggingScreen.gameObject.SetActive(false);
+            InitializeScreen(loggingScreen);
+            allScreens.Add(loggingScreen);
         }
 
-        var content = new GameObject("Content");
-        var contentRect = content.AddComponent<RectTransform>();
-        contentRect.SetParent(ms.transform, false);
-        contentRect.anchorMin = new Vector2(0f, 1f);
-        contentRect.anchorMax = new Vector2(1f, 1f);
-        contentRect.pivot = new Vector2(0.5f, 1f);
-        contentRect.anchoredPosition = Vector2.zero;
-        var layout = content.AddComponent<VerticalLayoutGroup>();
-        layout.childControlHeight = true;
-        layout.childControlWidth = true;
-        layout.childForceExpandHeight = false;
-        layout.childForceExpandWidth = true;
-        layout.spacing = 15f;
+        screen = mainScreen != null ? mainScreen.gameObject : null;
 
-        var selectables = new List<MenuSelectable>();
-        MenuSelectable s;
-        s = CreateSlider(content.transform, sliderTemplate, "Hornet Damage", 0.2f, 2f, ModConfig.Instance.hornetDamageMultiplier, v => ModConfig.Instance.hornetDamageMultiplier = v);
-        if (s != null) selectables.Add(s);
-        s = CreateSlider(content.transform, sliderTemplate, "Shade Damage", 0.2f, 2f, ModConfig.Instance.shadeDamageMultiplier, v => ModConfig.Instance.shadeDamageMultiplier = v);
-        if (s != null) selectables.Add(s);
-        s = CreateSlider(content.transform, sliderTemplate, "Shade Heal (Bind)", 0f, 6f, ModConfig.Instance.bindShadeHeal, v => ModConfig.Instance.bindShadeHeal = Mathf.RoundToInt(v), true);
-        if (s != null) selectables.Add(s);
-        s = CreateSlider(content.transform, sliderTemplate, "Hornet Heal (Bind)", 0f, 6f, ModConfig.Instance.bindHornetHeal, v => ModConfig.Instance.bindHornetHeal = Mathf.RoundToInt(v), true);
-        if (s != null) selectables.Add(s);
-        s = CreateSlider(content.transform, sliderTemplate, "Shade Focus Heal", 0f, 6f, ModConfig.Instance.focusShadeHeal, v => ModConfig.Instance.focusShadeHeal = Mathf.RoundToInt(v), true);
-        if (s != null) selectables.Add(s);
-        s = CreateSlider(content.transform, sliderTemplate, "Hornet Focus Heal", 0f, 6f, ModConfig.Instance.focusHornetHeal, v => ModConfig.Instance.focusHornetHeal = Mathf.RoundToInt(v), true);
-        if (s != null) selectables.Add(s);
-        s = CreateToggle(content.transform, toggleTemplate, "Damage Logging", ModConfig.Instance.logDamage, v => ModConfig.Instance.logDamage = v);
-        if (s != null) selectables.Add(s);
-        if (selectables.Count > 0)
-        {
-            firstSelectable = selectables[0];
-            if (ms != null)
-                ms.defaultHighlight = firstSelectable;
-        }
+        BuildMainMenu(ui, mainScreen, buttonTemplate);
+        BuildDifficultyMenu(ui, difficultyScreen, sliderTemplate);
+        BuildControlsMenu(ui, controlsScreen);
+        BuildLoggingMenu(ui, loggingScreen, toggleTemplate);
 
-        if (ms.backButton != null)
-        {
-            log.LogDebug("Wiring back button");
-            ms.backButton.OnSubmitPressed.AddListener(() => ui.StartCoroutine(Hide(ui)));
-        }
-
-        var mbl = screen.GetComponent<MenuButtonList>() ?? screen.AddComponent<MenuButtonList>();
-        mbl.ClearLastSelected();
-        var entryField = typeof(MenuButtonList).GetField("entries", BindingFlags.NonPublic | BindingFlags.Instance);
-        var entryType = entryField.FieldType.GetElementType();
-        var arr = Array.CreateInstance(entryType, selectables.Count);
-        for (int i = 0; i < selectables.Count; i++)
-        {
-            var e = Activator.CreateInstance(entryType);
-            entryType.GetField("selectable", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(e, selectables[i]);
-            arr.SetValue(e, i);
-        }
-        entryField.SetValue(mbl, arr);
-        mbl.SetupActive();
-
-        LayoutRebuilder.ForceRebuildLayoutImmediate(content.GetComponent<RectTransform>());
-
-        if (createdSliderTemplate)
+        if (createdSliderTemplate && sliderTemplate != null)
             Object.Destroy(sliderTemplate.gameObject);
-        if (createdToggleTemplate)
+        if (createdToggleTemplate && toggleTemplate != null)
             Object.Destroy(toggleTemplate.gameObject);
+        if (createdButtonTemplate && buttonTemplate != null)
+            Object.Destroy(buttonTemplate.gameObject);
 
         built = true;
-        log.LogInfo("Shade settings page built");
+        LogMenuInfo("Shade settings page built");
     }
 
     internal static void Inject(UIManager ui)
@@ -502,7 +1323,7 @@ public static class ShadeSettingsMenu
         {
             if (!loggedNullUI)
             {
-                log.LogWarning("Inject called with null UIManager");
+                LogMenuWarning("Inject called with null UIManager");
                 loggedNullUI = true;
             }
             return;
@@ -511,7 +1332,7 @@ public static class ShadeSettingsMenu
         {
             if (!loggedNoPauseMenu)
             {
-                log.LogWarning("pauseMenuScreen not yet available");
+                LogMenuWarning("pauseMenuScreen not yet available");
                 loggedNoPauseMenu = true;
             }
             return;
@@ -519,7 +1340,7 @@ public static class ShadeSettingsMenu
 
         // Ensure a screen exists for this UI
         Build(ui);
-        if (screen == null)
+        if (mainScreen == null)
             return;
 
         // Avoid duplicate buttons by scanning entire hierarchy
@@ -529,7 +1350,7 @@ public static class ShadeSettingsMenu
             {
                 if (!loggedButtonAlreadyPresent)
                 {
-                    log.LogInfo("ShadeSettingsButton already present; skipping injection");
+                    LogMenuInfo("ShadeSettingsButton already present; skipping injection");
                     loggedButtonAlreadyPresent = true;
                 }
                 return;
@@ -541,7 +1362,7 @@ public static class ShadeSettingsMenu
         {
             if (!loggedNoPauseButtonTemplates)
             {
-                log.LogWarning("No PauseMenuButton templates found");
+                LogMenuWarning("No PauseMenuButton templates found");
                 loggedNoPauseButtonTemplates = true;
             }
             return;
@@ -563,7 +1384,7 @@ public static class ShadeSettingsMenu
         {
             if (!loggedNoMenuButtonList)
             {
-                log.LogWarning("MenuButtonList not found on template parent");
+                LogMenuWarning("MenuButtonList not found on template parent");
                 loggedNoMenuButtonList = true;
             }
             return;
@@ -574,7 +1395,7 @@ public static class ShadeSettingsMenu
         {
             if (!loggedNullEntries)
             {
-                log.LogWarning("MenuButtonList entries field null");
+                LogMenuWarning("MenuButtonList entries field null");
                 loggedNullEntries = true;
             }
             return;
@@ -634,38 +1455,68 @@ public static class ShadeSettingsMenu
         dirtyField?.SetValue(list, true);
 
         list.SetupActive();
-        log.LogInfo("Injected ShadeSettingsButton into pause menu");
+        LogMenuInfo("Injected ShadeSettingsButton into pause menu");
     }
 
     internal static IEnumerator Show(UIManager ui)
     {
         Build(ui);
-        if (screen == null)
+        if (mainScreen == null)
         {
-            log.LogWarning("Show called but screen is null");
+            LogMenuWarning("Show called but main screen is null");
             yield break;
         }
 
-        log.LogInfo("Showing Shade settings page");
-        ui.pauseMenuScreen.gameObject.SetActive(false);
-        screen.SetActive(true);
-        if (firstSelectable != null)
+        LogMenuInfo("Showing Shade settings page");
+        if (ui.pauseMenuScreen != null)
+            ui.pauseMenuScreen.gameObject.SetActive(false);
+        if (templateSource != null)
         {
-            if (EventSystem.current != null)
-                EventSystem.current.SetSelectedGameObject(firstSelectable.gameObject);
-            UIManager.HighlightSelectableNoSound(firstSelectable.GetFirstInteractable());
+            templateSourceWasActive = templateSource.activeSelf;
+            templateSource.SetActive(false);
+        }
+        ShowScreen(mainScreen);
+        if (ui != null && mainScreen != null)
+        {
+            try
+            {
+                ui.StartCoroutine(ui.ShowMenu(mainScreen));
+            }
+            catch (Exception e)
+            {
+                LogMenuWarning($"Failed to animate Shade settings page: {e}");
+            }
         }
         yield break;
     }
 
     internal static void HideImmediate(UIManager ui)
     {
-        if (screen == null)
+        if (allScreens.Count == 0)
             return;
-        log.LogInfo("Hiding Shade settings page");
-        screen.SetActive(false);
-        if (ui != null && ui.pauseMenuScreen != null)
-            ui.pauseMenuScreen.gameObject.SetActive(true);
+        LogMenuInfo("Hiding Shade settings page");
+        foreach (var ms in allScreens)
+        {
+            if (ms != null)
+                ms.gameObject.SetActive(false);
+        }
+        activeScreen = null;
+        var targetUi = ui ?? UIManager.instance;
+        if (targetUi != null)
+        {
+            if (templateSource != null)
+                templateSource.SetActive(templateSourceWasActive);
+            try
+            {
+                if (targetUi.pauseMenuScreen != null)
+                    targetUi.pauseMenuScreen.gameObject.SetActive(true);
+                targetUi.StartCoroutine(targetUi.GoToPauseMenu());
+            }
+            catch (Exception e)
+            {
+                LogMenuWarning($"Failed to navigate back to pause menu: {e}");
+            }
+        }
         ModConfig.Save();
     }
 
@@ -677,13 +1528,12 @@ public static class ShadeSettingsMenu
 
     internal static void Clear()
     {
-        if (screen != null)
-        {
-            Object.Destroy(screen);
-            screen = null;
-        }
+        DestroyScreens();
         built = false;
         builtFor = null;
-        firstSelectable = null;
+        sliderLabelStyle = null;
+        sliderValueStyle = null;
+        toggleLabelStyle = null;
+        fallbackFont = null;
     }
 }


### PR DESCRIPTION
## Summary
- strip unwanted behaviours from cloned menu screens, rebuild the content root immediately, and convert menu cancel actions to custom routing so the base pause/options UI no longer bleeds into the shade settings
- hook the shade settings show/hide flow into UIManager.ShowMenu/GoToPauseMenu so controller navigation highlights correctly and backing out returns to a clean pause menu state
- gate shade input processing behind a pause check and zero rigidbody velocity during fixed update so the companion stays frozen while the game is paused

## Testing
- dotnet build -c Release *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c833e60958832084d3cfa28bc1bd4b