### PR TITLE
Refactor shade persistence into dedicated runtime

### DIFF
--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
 using InControl;
+using LegacyoftheAbyss.Shade;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -79,9 +80,9 @@ public partial class LegacyHelper
                     }
                 }
                 // Fallback: ensure saved state revives next spawn
-                if (savedShadeMax > 0)
+                if (ShadeRuntime.PersistentState.HasData)
                 {
-                    savedShadeHP = Mathf.Max(savedShadeHP, 1);
+                    ShadeRuntime.EnsureMinimumHealth(1);
                 }
             }
             catch { }

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using LegacyoftheAbyss.Shade;
 using UnityEngine;
 using GlobalEnums;
 
@@ -10,221 +11,6 @@ public partial class LegacyHelper
 {
     public partial class ShadeController : MonoBehaviour
     {
-        // Movement and leash
-        public float moveSpeed = 10f;
-        public float sprintMultiplier = 2.5f;
-        public float maxDistance = 14f;
-        public float softLeashRadius = 12f;
-        public float hardLeashRadius = 22f;
-        public float snapLeashRadius = 38f;
-        public float softPullSpeed = 6f;
-        public float hardPullSpeed = 30f;
-        public float hardLeashTimeout = 2.5f;
-        private bool inHardLeash;
-        private float hardLeashTimer;
-        private Rigidbody2D rb;
-        private Collider2D bodyCol;
-        private int shadeMaxHP;
-        private int shadeHP;
-        private float hazardCooldown;
-        private float baseMaxDistance, baseSoftLeashRadius, baseHardLeashRadius, baseSnapLeashRadius;
-        private bool wasInactive;
-        public float hitKnockbackForce = 6f;
-        private Vector2 knockbackVelocity;
-        private float knockbackTimer;
-        private BattleScene cachedBattle;
-        private float battleCheckTimer;
-
-        private static readonly string[] IgnoreDamageTokens =
-            {"alert range", "attack range", "wake", "close range", "sight range", "terrain", "range", "physics pusher"};
-
-        // Ranged attack
-        public float projectileSpeed = 22f;
-        public float fireCooldown = 0.25f;
-        public float nailCooldown = 0.3f;
-        public Vector2 muzzleOffset = new Vector2(0.9f, 0f);
-
-        private Transform hornetTransform;
-        private float fireTimer;
-        private SpriteRenderer sr;
-        private float _spriteScale = 1.5f;
-        public float SpriteScale
-        {
-            get => _spriteScale;
-            set
-            {
-                _spriteScale = value;
-                if (transform != null)
-                    transform.localScale = Vector3.one * _spriteScale;
-            }
-        }
-        private Sprite[] idleAnimFrames;
-        private Sprite[] floatAnimFrames;
-        private Sprite[] vengefulAnimFrames;
-        private Sprite[] shadeSoulAnimFrames;
-        private Sprite[] fireballCastAnimFrames;
-        private Sprite[] quakeCastAnimFrames;
-        private Sprite[] shriekCastAnimFrames;
-        private Sprite[] abyssShriekAnimFrames;
-        private Sprite[] howlingWraithsAnimFrames;
-        private Sprite[] deathAnimFrames;
-        private Sprite[] descendAnimFrames;
-        private Sprite[] descendAuraAnimFrames;
-        private Sprite[] dDiveSlamAnimFrames;
-        private Sprite[] dDarkSlamAnimFrames;
-        private Sprite[] dDarkBurstAnimFrames;
-        private Sprite inactiveSprite;
-        private SpriteRenderer inactivePulseSr;
-        private Sprite[] currentAnimFrames;
-        private int animFrameIndex;
-        private float animTimer;
-        private Coroutine spawnRoutine;
-        private bool pendingSpawnAnimation;
-        private bool isSpawning;
-        private const float AnimFrameTime = 0.1f;
-        private Vector2 lastMoveDelta;
-        private Renderer[] shadeLightRenderers;
-        public float simpleLightSize = 14f;
-        private static Texture2D s_simpleLightTex;
-        private static Material s_simpleAdditiveMat;
-        private static Mesh s_simpleQuadMesh;
-        private static Material s_sprintBurstMat;
-        private int facing = 1;
-        private float nailTimer;
-        internal static bool suppressActivateOnSlash;
-        internal static Transform expectedSlashParent;
-
-        private struct AxisLeashLimits
-        {
-            public float NegativeSoft;
-            public float PositiveSoft;
-            public float NegativeHard;
-            public float PositiveHard;
-            public float NegativeSnap;
-            public float PositiveSnap;
-        }
-
-        private struct DynamicLeashLimits
-        {
-            public AxisLeashLimits X;
-            public AxisLeashLimits Y;
-        }
-
-        private const float LeashScreenPadding = 0.75f;
-        private const float SoftLimitRatio = 0.9f;
-        private const float SnapExtraMultiplier = 1.2f;
-        private const float SnapExtraMin = 0.75f;
-        private const float SnapMinWhenNoRoom = 0.25f;
-
-        private bool canTakeDamage = true;
-        private Vector2 capturedMoveInput;
-        private float capturedHorizontalInput;
-        private bool capturedSprintHeld;
-        // Spells use Fire + Up (Shriek) or Fire + Down (Descending Dark)
-
-        // Teleport channel
-        private bool isChannelingTeleport;
-        private float teleportChannelTimer;
-        public float teleportChannelTime = 0.6f;
-        private float teleportCooldownTimer;
-        public float teleportCooldown = 1.5f;
-
-        private bool sprintUnlocked;
-        private bool isSprinting;
-        private float sprintDashTimer;
-        private float sprintDashCooldownTimer;
-        public float sprintDashMultiplier = 7.5f;
-        public float sprintDashDuration = 0.075f;
-        public float sprintDashCooldown = 1f;
-        private ParticleSystem activeDashPs;
-        private Vector2 activeDashDir;
-
-        // Inactive state (at 0 HP)
-        private bool isInactive;
-        private bool isDying;
-        private Coroutine deathRoutine;
-
-        // Shade Soul resource
-        public int shadeSoulMax = 99;
-        public int shadeSoul;
-        public int soulGainPerHit = 11;
-        public int projectileSoulCost = 33;
-        public int shriekSoulCost = 33;
-        public int quakeSoulCost = 33;
-        private float shriekTimer;
-        private float quakeTimer;
-        public float shriekCooldown = 0.5f;
-        public float quakeCooldown = 1.1f;
-        
-        // Focus (heal) ability
-        public int focusSoulCost = 33;
-        public float focusChannelTime = 1.25f;
-        private bool isFocusing;
-        private float focusTimer;
-        private float focusAlphaWhileChannel = 0.75f;
-        private float focusHealRange = 6f;
-        private float focusSoulAccumulator;
-        private Renderer focusAuraRenderer;
-        private float focusAuraBaseSize = 12f;
-        private AudioSource focusSfx;
-        private AudioClip sfxFocusCharge;
-        private AudioClip sfxFocusComplete;
-        private AudioClip sfxFocusReady;
-        private int lastSoulForReady = -1;
-
-        private SimpleHUD cachedHud;
-        private float hurtCooldown;
-        private const float HurtIFrameSeconds = 1.35f;
-        private const float ReviveIFrameSeconds = 1.5f;
-        private float ignoreRefreshTimer;
-        private float hornetIgnoreRefreshTimer;
-        private bool isCastingSpell;
-
-        private int lastSavedHP;
-        private int lastSavedMax;
-        private int lastSavedSoul;
-        private bool lastSavedCanTakeDamage = true;
-
-        public void RestorePersistentState(int hp, int max, int soul, bool canDamage = true)
-        {
-            shadeMaxHP = Mathf.Max(1, max);
-            shadeHP = Mathf.Clamp(hp, 0, shadeMaxHP);
-            shadeSoul = Mathf.Clamp(soul, 0, shadeSoulMax);
-            canTakeDamage = canDamage;
-            lastSavedCanTakeDamage = canTakeDamage;
-        }
-
-        public void FullHealFromBench()
-        {
-            shadeHP = Mathf.Max(shadeHP, shadeMaxHP);
-            if (shadeHP > 0)
-            {
-                isInactive = false;
-                CancelDeathAnimation();
-            }
-            PushShadeStatsToHud();
-        }
-
-        public void ReviveToAtLeast(int hp)
-        {
-            int target = Mathf.Max(1, hp);
-            shadeHP = Mathf.Max(shadeHP, target);
-            if (shadeHP > 0)
-            {
-                isInactive = false;
-                CancelDeathAnimation();
-            }
-            PushShadeStatsToHud();
-            PersistIfChanged();
-        }
-
-        public int GetCurrentHP() => shadeHP;
-        public int GetMaxHP() => shadeMaxHP;
-        public int GetShadeSoul() => shadeSoul;
-        public bool GetCanTakeDamage() => canTakeDamage;
-
-        public void Init(Transform hornet) { hornetTransform = hornet; }
-
         private void Start()
         {
             SetupPhysics();
@@ -665,31 +451,6 @@ public partial class LegacyHelper
                 }
             }
             catch { }
-        }
-
-        private void PersistIfChanged()
-        {
-            if (lastSavedHP != shadeHP || lastSavedMax != shadeMaxHP || lastSavedSoul != shadeSoul || lastSavedCanTakeDamage != canTakeDamage)
-            {
-                LegacyHelper.SaveShadeState(shadeHP, shadeMaxHP, shadeSoul, canTakeDamage);
-                lastSavedHP = shadeHP; lastSavedMax = shadeMaxHP; lastSavedSoul = shadeSoul; lastSavedCanTakeDamage = canTakeDamage;
-            }
-        }
-
-        private void PushSoulToHud()
-        {
-            if (cachedHud)
-            {
-                try { cachedHud.SetShadeSoul(shadeSoul, shadeSoulMax); } catch { }
-            }
-        }
-
-        private void PushShadeStatsToHud()
-        {
-            if (cachedHud)
-            {
-                try { cachedHud.SetShadeStats(shadeHP, shadeMaxHP); } catch { }
-            }
         }
 
         private void CaptureMovementInput()
@@ -1260,17 +1021,25 @@ public partial class LegacyHelper
                 try
                 {
                     var pd = GameManager.instance != null ? GameManager.instance.playerData : null;
-                    if (pd == null) return 0;
-                    int c = 0;
-                    if (pd.hasNeedleThrow) c++;
-                    if (pd.hasThreadSphere) c++;
-                    if (pd.hasSilkCharge) c++;
-                    if (pd.hasParry) c++;
-                    if (pd.hasSilkBomb) c++;
-                    if (pd.hasSilkBossNeedle) c++;
-                    return Mathf.Clamp(c, 0, 6);
+                    if (pd != null)
+                    {
+                        int c = 0;
+                        if (pd.hasNeedleThrow) c++;
+                        if (pd.hasThreadSphere) c++;
+                        if (pd.hasSilkCharge) c++;
+                        if (pd.hasParry) c++;
+                        if (pd.hasSilkBomb) c++;
+                        if (pd.hasSilkBossNeedle) c++;
+                        c = Mathf.Clamp(c, 0, 6);
+                        ShadeRuntime.SyncSpellProgress(c);
+                        return c;
+                    }
                 }
-                catch { return 0; }
+                catch
+                {
+                }
+
+                return ShadeRuntime.PersistentState.SpellProgress;
             }
         }
         private bool IsProjectileUnlocked() => ShadeSpellProgress >= 1;

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -1,0 +1,188 @@
+#nullable disable
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+using GlobalEnums;
+
+public partial class LegacyHelper
+{
+    public partial class ShadeController : MonoBehaviour
+    {
+        // Movement and leash
+        public float moveSpeed = 10f;
+        public float sprintMultiplier = 2.5f;
+        public float maxDistance = 14f;
+        public float softLeashRadius = 12f;
+        public float hardLeashRadius = 22f;
+        public float snapLeashRadius = 38f;
+        public float softPullSpeed = 6f;
+        public float hardPullSpeed = 30f;
+        public float hardLeashTimeout = 2.5f;
+        private bool inHardLeash;
+        private float hardLeashTimer;
+        private Rigidbody2D rb;
+        private Collider2D bodyCol;
+        private int shadeMaxHP;
+        private int shadeHP;
+        private float hazardCooldown;
+        private float baseMaxDistance, baseSoftLeashRadius, baseHardLeashRadius, baseSnapLeashRadius;
+        private bool wasInactive;
+        public float hitKnockbackForce = 6f;
+        private Vector2 knockbackVelocity;
+        private float knockbackTimer;
+        private BattleScene cachedBattle;
+        private float battleCheckTimer;
+
+        private static readonly string[] IgnoreDamageTokens =
+            {"alert range", "attack range", "wake", "close range", "sight range", "terrain", "range", "physics pusher"};
+
+        // Ranged attack
+        public float projectileSpeed = 22f;
+        public float fireCooldown = 0.25f;
+        public float nailCooldown = 0.3f;
+        public Vector2 muzzleOffset = new Vector2(0.9f, 0f);
+
+        private Transform hornetTransform;
+        private float fireTimer;
+        private SpriteRenderer sr;
+        private float _spriteScale = 1.5f;
+        public float SpriteScale
+        {
+            get => _spriteScale;
+            set
+            {
+                _spriteScale = value;
+                if (transform != null)
+                    transform.localScale = Vector3.one * _spriteScale;
+            }
+        }
+        private Sprite[] idleAnimFrames;
+        private Sprite[] floatAnimFrames;
+        private Sprite[] vengefulAnimFrames;
+        private Sprite[] shadeSoulAnimFrames;
+        private Sprite[] fireballCastAnimFrames;
+        private Sprite[] quakeCastAnimFrames;
+        private Sprite[] shriekCastAnimFrames;
+        private Sprite[] abyssShriekAnimFrames;
+        private Sprite[] howlingWraithsAnimFrames;
+        private Sprite[] deathAnimFrames;
+        private Sprite[] descendAnimFrames;
+        private Sprite[] descendAuraAnimFrames;
+        private Sprite[] dDiveSlamAnimFrames;
+        private Sprite[] dDarkSlamAnimFrames;
+        private Sprite[] dDarkBurstAnimFrames;
+        private Sprite inactiveSprite;
+        private SpriteRenderer inactivePulseSr;
+        private Sprite[] currentAnimFrames;
+        private int animFrameIndex;
+        private float animTimer;
+        private Coroutine spawnRoutine;
+        private bool pendingSpawnAnimation;
+        private bool isSpawning;
+        private const float AnimFrameTime = 0.1f;
+        private Vector2 lastMoveDelta;
+        private Renderer[] shadeLightRenderers;
+        public float simpleLightSize = 14f;
+        private static Texture2D s_simpleLightTex;
+        private static Material s_simpleAdditiveMat;
+        private static Mesh s_simpleQuadMesh;
+        private static Material s_sprintBurstMat;
+        private int facing = 1;
+        private float nailTimer;
+        internal static bool suppressActivateOnSlash;
+        internal static Transform expectedSlashParent;
+
+        private struct AxisLeashLimits
+        {
+            public float NegativeSoft;
+            public float PositiveSoft;
+            public float NegativeHard;
+            public float PositiveHard;
+            public float NegativeSnap;
+            public float PositiveSnap;
+        }
+
+        private struct DynamicLeashLimits
+        {
+            public AxisLeashLimits X;
+            public AxisLeashLimits Y;
+        }
+
+        private const float LeashScreenPadding = 0.75f;
+        private const float SoftLimitRatio = 0.9f;
+        private const float SnapExtraMultiplier = 1.2f;
+        private const float SnapExtraMin = 0.75f;
+        private const float SnapMinWhenNoRoom = 0.25f;
+
+        private bool canTakeDamage = true;
+        private Vector2 capturedMoveInput;
+        private float capturedHorizontalInput;
+        private bool capturedSprintHeld;
+        // Spells use Fire + Up (Shriek) or Fire + Down (Descending Dark)
+
+        // Teleport channel
+        private bool isChannelingTeleport;
+        private float teleportChannelTimer;
+        public float teleportChannelTime = 0.6f;
+        private float teleportCooldownTimer;
+        public float teleportCooldown = 1.5f;
+
+        private bool sprintUnlocked;
+        private bool isSprinting;
+        private float sprintDashTimer;
+        private float sprintDashCooldownTimer;
+        public float sprintDashMultiplier = 7.5f;
+        public float sprintDashDuration = 0.075f;
+        public float sprintDashCooldown = 1f;
+        private ParticleSystem activeDashPs;
+        private Vector2 activeDashDir;
+
+        // Inactive state (at 0 HP)
+        private bool isInactive;
+        private bool isDying;
+        private Coroutine deathRoutine;
+
+        // Shade Soul resource
+        public int shadeSoulMax = 99;
+        public int shadeSoul;
+        public int soulGainPerHit = 11;
+        public int projectileSoulCost = 33;
+        public int shriekSoulCost = 33;
+        public int quakeSoulCost = 33;
+        private float shriekTimer;
+        private float quakeTimer;
+        public float shriekCooldown = 0.5f;
+        public float quakeCooldown = 1.1f;
+
+        // Focus (heal) ability
+        public int focusSoulCost = 33;
+        public float focusChannelTime = 1.25f;
+        private bool isFocusing;
+        private float focusTimer;
+        private float focusAlphaWhileChannel = 0.75f;
+        private float focusHealRange = 6f;
+        private float focusSoulAccumulator;
+        private Renderer focusAuraRenderer;
+        private float focusAuraBaseSize = 12f;
+        private AudioSource focusSfx;
+        private AudioClip sfxFocusCharge;
+        private AudioClip sfxFocusComplete;
+        private AudioClip sfxFocusReady;
+        private int lastSoulForReady = -1;
+
+        private SimpleHUD cachedHud;
+        private float hurtCooldown;
+        private const float HurtIFrameSeconds = 1.35f;
+        private const float ReviveIFrameSeconds = 1.5f;
+        private float ignoreRefreshTimer;
+        private float hornetIgnoreRefreshTimer;
+        private bool isCastingSpell;
+
+        private int lastSavedHP;
+        private int lastSavedMax;
+        private int lastSavedSoul;
+        private bool lastSavedCanTakeDamage = true;
+    }
+}

--- a/LegacyHelper.ShadeController.Persistence.cs
+++ b/LegacyHelper.ShadeController.Persistence.cs
@@ -1,0 +1,73 @@
+#nullable disable
+using UnityEngine;
+
+public partial class LegacyHelper
+{
+    public partial class ShadeController
+    {
+        public void RestorePersistentState(int hp, int max, int soul, bool canDamage = true)
+        {
+            shadeMaxHP = Mathf.Max(1, max);
+            shadeHP = Mathf.Clamp(hp, 0, shadeMaxHP);
+            shadeSoul = Mathf.Clamp(soul, 0, shadeSoulMax);
+            canTakeDamage = canDamage;
+            lastSavedCanTakeDamage = canTakeDamage;
+        }
+
+        public void FullHealFromBench()
+        {
+            shadeHP = Mathf.Max(shadeHP, shadeMaxHP);
+            if (shadeHP > 0)
+            {
+                isInactive = false;
+                CancelDeathAnimation();
+            }
+            PushShadeStatsToHud();
+        }
+
+        public void ReviveToAtLeast(int hp)
+        {
+            int target = Mathf.Max(1, hp);
+            shadeHP = Mathf.Max(shadeHP, target);
+            if (shadeHP > 0)
+            {
+                isInactive = false;
+                CancelDeathAnimation();
+            }
+            PushShadeStatsToHud();
+            PersistIfChanged();
+        }
+
+        public int GetCurrentHP() => shadeHP;
+        public int GetMaxHP() => shadeMaxHP;
+        public int GetShadeSoul() => shadeSoul;
+        public bool GetCanTakeDamage() => canTakeDamage;
+
+        public void Init(Transform hornet) { hornetTransform = hornet; }
+
+        private void PersistIfChanged()
+        {
+            if (lastSavedHP != shadeHP || lastSavedMax != shadeMaxHP || lastSavedSoul != shadeSoul || lastSavedCanTakeDamage != canTakeDamage)
+            {
+                LegacyHelper.SaveShadeState(shadeHP, shadeMaxHP, shadeSoul, canTakeDamage);
+                lastSavedHP = shadeHP; lastSavedMax = shadeMaxHP; lastSavedSoul = shadeSoul; lastSavedCanTakeDamage = canTakeDamage;
+            }
+        }
+
+        private void PushSoulToHud()
+        {
+            if (cachedHud)
+            {
+                try { cachedHud.SetShadeSoul(shadeSoul, shadeSoulMax); } catch { }
+            }
+        }
+
+        private void PushShadeStatsToHud()
+        {
+            if (cachedHud)
+            {
+                try { cachedHud.SetShadeStats(shadeHP, shadeMaxHP); } catch { }
+            }
+        }
+    }
+}

--- a/Shade/ShadePersistentState.cs
+++ b/Shade/ShadePersistentState.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using UnityEngine;
+
+namespace LegacyoftheAbyss.Shade
+{
+    /// <summary>
+    /// Represents the portions of the shade's runtime state that need to persist between scene loads.
+    /// This class intentionally avoids any references to Unity components so that it can be tested in isolation.
+    /// </summary>
+    internal sealed class ShadePersistentState
+    {
+        private const int MaxSpellProgress = 6;
+
+        public int CurrentHP { get; private set; } = -1;
+        public int MaxHP { get; private set; } = -1;
+        public int Soul { get; private set; } = -1;
+        public bool CanTakeDamage { get; private set; } = true;
+        public int SpellProgress { get; private set; }
+            = 0;
+
+        public bool HasData => MaxHP > 0;
+
+        public ShadePersistentState Clone()
+        {
+            return new ShadePersistentState
+            {
+                CurrentHP = CurrentHP,
+                MaxHP = MaxHP,
+                Soul = Soul,
+                CanTakeDamage = CanTakeDamage,
+                SpellProgress = SpellProgress
+            };
+        }
+
+        public void Capture(int currentHp, int maxHp, int soul, bool? canTakeDamage = null)
+        {
+            MaxHP = Mathf.Max(1, maxHp);
+            CurrentHP = Mathf.Clamp(currentHp, 0, MaxHP);
+            Soul = Mathf.Max(0, soul);
+            if (canTakeDamage.HasValue)
+            {
+                CanTakeDamage = canTakeDamage.Value;
+            }
+        }
+
+        public void Reset()
+        {
+            CurrentHP = -1;
+            MaxHP = -1;
+            Soul = -1;
+            CanTakeDamage = true;
+            SpellProgress = 0;
+        }
+
+        public void ForceMinimumHealth(int minimum)
+        {
+            if (!HasData)
+            {
+                return;
+            }
+
+            int required = Mathf.Max(0, minimum);
+            CurrentHP = Mathf.Clamp(Mathf.Max(CurrentHP, required), 0, MaxHP);
+        }
+
+        public void AdvanceSpellProgress()
+        {
+            SpellProgress = Mathf.Clamp(SpellProgress + 1, 0, MaxSpellProgress);
+        }
+
+        public void SetSpellProgress(int progress)
+        {
+            SpellProgress = Mathf.Clamp(progress, 0, MaxSpellProgress);
+        }
+    }
+}

--- a/Shade/ShadeRuntime.cs
+++ b/Shade/ShadeRuntime.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+namespace LegacyoftheAbyss.Shade
+{
+    /// <summary>
+    /// Central coordination point for shade state that has to live longer than a single scene. The runtime
+    /// exposes a simple API today but can later be extended to coordinate with save slots, file IO, or
+    /// charm inventories without forcing the rest of the mod to understand those details.
+    /// </summary>
+    internal static class ShadeRuntime
+    {
+        private static readonly ShadePersistentState s_persistentState = new ShadePersistentState();
+        private static readonly ShadeSaveSlotRepository s_saveSlots = new ShadeSaveSlotRepository();
+
+        public static ShadePersistentState PersistentState => s_persistentState;
+
+        public static ShadeSaveSlotRepository SaveSlots => s_saveSlots;
+
+        public static bool TryGetPersistentState(out int currentHp, out int maxHp, out int soul, out bool canTakeDamage)
+        {
+            if (!s_persistentState.HasData)
+            {
+                currentHp = -1;
+                maxHp = -1;
+                soul = -1;
+                canTakeDamage = true;
+                return false;
+            }
+
+            currentHp = s_persistentState.CurrentHP;
+            maxHp = s_persistentState.MaxHP;
+            soul = s_persistentState.Soul;
+            canTakeDamage = s_persistentState.CanTakeDamage;
+            return true;
+        }
+
+        public static void CaptureState(int currentHp, int maxHp, int soul, bool? canTakeDamage = null)
+        {
+            s_persistentState.Capture(currentHp, maxHp, soul, canTakeDamage);
+        }
+
+        public static void EnsureMinimumHealth(int minimum)
+        {
+            s_persistentState.ForceMinimumHealth(minimum);
+        }
+
+        public static void Clear()
+        {
+            s_persistentState.Reset();
+        }
+
+        public static void NotifyHornetSpellUnlocked()
+        {
+            s_persistentState.AdvanceSpellProgress();
+        }
+
+        public static void SyncSpellProgress(int progress)
+        {
+            s_persistentState.SetSpellProgress(progress);
+        }
+    }
+}

--- a/Shade/ShadeSaveSlotRepository.cs
+++ b/Shade/ShadeSaveSlotRepository.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LegacyoftheAbyss.Shade
+{
+    /// <summary>
+    /// Tracks a small collection of shade save slots so that future systems can attach shade-specific
+    /// progress to the game's existing save files. The repository is intentionally simple today but
+    /// provides cloning semantics to avoid accidental sharing of mutable state.
+    /// </summary>
+    internal sealed class ShadeSaveSlotRepository
+    {
+        private readonly Dictionary<int, ShadePersistentState> _slots;
+
+        public ShadeSaveSlotRepository(int maxSlots = 4)
+        {
+            if (maxSlots <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxSlots), "Shade save repository must manage at least one slot.");
+            }
+
+            MaxSlots = maxSlots;
+            _slots = new Dictionary<int, ShadePersistentState>(MaxSlots);
+        }
+
+        public int MaxSlots { get; }
+
+        public IEnumerable<int> KnownSlots => _slots.Keys.OrderBy(k => k);
+
+        public ShadePersistentState GetOrCreateSlot(int slot)
+        {
+            if (!_slots.TryGetValue(slot, out var existing))
+            {
+                existing = new ShadePersistentState();
+                _slots[slot] = existing;
+            }
+
+            return existing;
+        }
+
+        public bool TryGetSlot(int slot, out ShadePersistentState state)
+        {
+            if (_slots.TryGetValue(slot, out var existing))
+            {
+                state = existing.Clone();
+                return true;
+            }
+
+            state = new ShadePersistentState();
+            return false;
+        }
+
+        public void UpdateSlot(int slot, ShadePersistentState data)
+        {
+            if (slot < 0 || slot >= MaxSlots)
+            {
+                return;
+            }
+
+            _slots[slot] = (data ?? new ShadePersistentState()).Clone();
+        }
+
+        public void ClearSlot(int slot)
+        {
+            _slots.Remove(slot);
+        }
+
+        public void ResetAll()
+        {
+            _slots.Clear();
+        }
+    }
+}

--- a/Tests/ShadePersistenceTests.cs
+++ b/Tests/ShadePersistenceTests.cs
@@ -1,0 +1,96 @@
+using System.Linq;
+using LegacyoftheAbyss.Shade;
+using Xunit;
+
+public class ShadePersistentStateTests
+{
+    [Fact]
+    public void CaptureClampsValues()
+    {
+        var state = new ShadePersistentState();
+        state.Capture(-10, -5, -20, false);
+
+        Assert.True(state.HasData);
+        Assert.Equal(1, state.MaxHP);
+        Assert.Equal(0, state.CurrentHP);
+        Assert.Equal(0, state.Soul);
+        Assert.False(state.CanTakeDamage);
+    }
+
+    [Fact]
+    public void ForceMinimumHealthRespectsBounds()
+    {
+        var state = new ShadePersistentState();
+        state.Capture(1, 3, 0, true);
+        state.ForceMinimumHealth(4);
+
+        Assert.Equal(3, state.CurrentHP); // clamped to max HP
+
+        state.ForceMinimumHealth(2);
+        Assert.Equal(3, state.CurrentHP); // remains at higher value
+    }
+
+    [Fact]
+    public void SpellProgressClampsAndPersists()
+    {
+        var state = new ShadePersistentState();
+        for (int i = 0; i < 10; i++)
+        {
+            state.AdvanceSpellProgress();
+        }
+
+        Assert.Equal(6, state.SpellProgress);
+
+        state.SetSpellProgress(-5);
+        Assert.Equal(0, state.SpellProgress);
+    }
+}
+
+public class ShadeSaveSlotRepositoryTests
+{
+    [Fact]
+    public void UpdateSlotStoresClone()
+    {
+        var repository = new ShadeSaveSlotRepository();
+        var original = new ShadePersistentState();
+        original.Capture(2, 5, 10, false);
+
+        repository.UpdateSlot(1, original);
+
+        original.Capture(1, 3, 1, true);
+        Assert.True(repository.TryGetSlot(1, out var stored));
+        Assert.NotSame(original, stored);
+        Assert.Equal(2, stored.CurrentHP);
+        Assert.Equal(5, stored.MaxHP);
+        Assert.Equal(10, stored.Soul);
+        Assert.False(stored.CanTakeDamage);
+    }
+
+    [Fact]
+    public void GetOrCreateSlotReturnsLiveReference()
+    {
+        var repository = new ShadeSaveSlotRepository();
+        var slot = repository.GetOrCreateSlot(0);
+        slot.Capture(3, 6, 12, true);
+
+        var sameSlot = repository.GetOrCreateSlot(0);
+        Assert.Same(slot, sameSlot);
+        Assert.Equal(3, sameSlot.CurrentHP);
+    }
+
+    [Fact]
+    public void ResetAndClearManageKnownSlots()
+    {
+        var repository = new ShadeSaveSlotRepository();
+        repository.UpdateSlot(0, new ShadePersistentState());
+        repository.UpdateSlot(2, new ShadePersistentState());
+
+        Assert.True(repository.KnownSlots.SequenceEqual(new[] { 0, 2 }));
+
+        repository.ClearSlot(2);
+        Assert.True(repository.KnownSlots.SequenceEqual(new[] { 0 }));
+
+        repository.ResetAll();
+        Assert.Empty(repository.KnownSlots);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a shade runtime layer with persistent state and save slot scaffolding for future features
- update LegacyHelper and ShadeController to consume the runtime, split controller state/persistence into partials, and synchronize spell unlock tracking
- add unit tests that cover the new shade persistence and repository utilities

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd69d8fa348320b3a84cc43dcb08b0