### PR TITLE
Add shade charm inventory tab and fix HUD/menu issues

### DIFF
--- a/HUD.UI.cs
+++ b/HUD.UI.cs
@@ -11,6 +11,8 @@ public partial class SimpleHUD
         // Canvas
         canvas = gameObject.AddComponent<Canvas>();
         canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvas.overrideSorting = true;
+        canvas.sortingOrder = -100;
         scaler = gameObject.AddComponent<CanvasScaler>();
         scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
         scaler.referenceResolution = new Vector2(1920, 1080);
@@ -36,6 +38,8 @@ public partial class SimpleHUD
         soulOrbRoot.sizeDelta = orbPixels * uiScale * 0.85f;
         soulOrbRoot.anchoredPosition = new Vector2(-200f * uiScale, -20f * uiScale);
         soulOrbRoot.localScale = new Vector3(-1f, 1f, 1f); // mirror like previous frame
+        orbGameplayScale = soulOrbRoot.localScale;
+        orbMenuScale = new Vector3(-orbGameplayScale.x, orbGameplayScale.y, orbGameplayScale.z);
 
         // Background
         var soulBgGO = new GameObject("SoulBackground");
@@ -97,6 +101,8 @@ public partial class SimpleHUD
             soulOrbRoot.anchoredPosition.x,
             orbCenterY + (maskHeight * 0.5f)
         );
+        healthGameplayScale = hRect.localScale;
+        healthMenuScale = new Vector3(-healthGameplayScale.x, healthGameplayScale.y, healthGameplayScale.z);
 
         BuildMasks(hRect, uiScale);
 
@@ -106,6 +112,7 @@ public partial class SimpleHUD
             unlockPopup = gameObject.AddComponent<ShadeUnlockPopup>();
         }
         unlockPopup.Initialize(canvas, GetUIScale);
+        UpdateMenuOrientation(ShouldTreatAsMenu());
     }
 
     private void RefreshHealth()

--- a/LegacyHelper.Core.cs
+++ b/LegacyHelper.Core.cs
@@ -187,6 +187,7 @@ public partial class LegacyHelper : BaseUnityPlugin
                 if (sc != null)
                 {
                     sc.TeleportToPosition(pos);
+                    sc.SuppressHazardDamage(1.5f);
                     sc.TriggerSpawnEntrance();
                     SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
                     RequestShadeLoadoutRecompute();
@@ -211,6 +212,8 @@ public partial class LegacyHelper : BaseUnityPlugin
         {
             scNew.RestorePersistentState(savedHp, savedMax, savedSoul, savedCanTakeDamage);
         }
+
+        scNew.SuppressHazardDamage(1.5f);
 
         var sr = helper.AddComponent<SpriteRenderer>();
 

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -1855,6 +1855,17 @@ public partial class LegacyHelper
             }
         }
 
+        public void SuppressHazardDamage(float duration)
+        {
+            if (duration <= 0f)
+            {
+                return;
+            }
+
+            hazardCooldown = Mathf.Max(hazardCooldown, duration);
+            hurtCooldown = Mathf.Max(hurtCooldown, duration);
+        }
+
         private Vector2 ClampAgainstTransitionGates(Vector2 proposed)
         {
             try

--- a/ShadeInventoryPane.cs
+++ b/ShadeInventoryPane.cs
@@ -701,6 +701,7 @@ internal static class ShadeInventoryPaneIntegration
         var newList = panes.ToList();
 
         int insertIndex = -1;
+
         for (int i = 0; i < panes.Length; i++)
         {
             var existing = panes[i];
@@ -709,11 +710,35 @@ internal static class ShadeInventoryPaneIntegration
                 continue;
             }
 
-            string name = existing.gameObject != null ? existing.gameObject.name : existing.name;
-            if (!string.IsNullOrEmpty(name))
+            string typeName = existing.GetType().Name;
+            if (!string.IsNullOrEmpty(typeName) &&
+                typeName.IndexOf("Crest", StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                if (name.IndexOf("Charm", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    name.IndexOf("Tool", StringComparison.OrdinalIgnoreCase) >= 0)
+                insertIndex = i + 1;
+                break;
+            }
+        }
+
+        if (insertIndex < 0)
+        {
+            for (int i = 0; i < panes.Length; i++)
+            {
+                var existing = panes[i];
+                if (!existing)
+                {
+                    continue;
+                }
+
+                string name = existing.gameObject != null ? existing.gameObject.name : existing.name;
+                string typeName = existing.GetType().Name;
+                bool matchesName = !string.IsNullOrEmpty(name) &&
+                    (name.IndexOf("Charm", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                     name.IndexOf("Tool", StringComparison.OrdinalIgnoreCase) >= 0);
+                bool matchesType = !string.IsNullOrEmpty(typeName) &&
+                    (typeName.IndexOf("Charm", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                     typeName.IndexOf("Tool", StringComparison.OrdinalIgnoreCase) >= 0);
+
+                if (matchesName || matchesType)
                 {
                     insertIndex = i + 1;
                     break;


### PR DESCRIPTION
## Summary
- add the Shade charm pane to the inventory tabs by injecting a custom pane after the Crest tab
- rework the HUD canvas to sit behind menus, detect menu states, and mirror the layout when inventory screens are active
- ensure the shade gains temporary hazard immunity after scene transitions so it no longer spawns at 1 HP

## Testing
- `dotnet test` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce605dfb248320a07ec0bfdc0aeebe