### PR TITLE
Add layout diagnostics for shade charm pane

### DIFF
--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -474,6 +474,19 @@ public partial class LegacyHelper
 
         private void Update()
         {
+            if (pendingCharmLoadoutRecompute && baselineStatsInitialized)
+            {
+                pendingCharmLoadoutRecompute = false;
+                try
+                {
+                    RecomputeCharmLoadout();
+                }
+                catch
+                {
+                    pendingCharmLoadoutRecompute = true;
+                }
+            }
+
             if (hornetTransform == null) return;
 
             if (GameIsPaused())

--- a/ShadeInventoryPane.cs
+++ b/ShadeInventoryPane.cs
@@ -804,7 +804,7 @@ internal sealed class ShadeInventoryPane : InventoryPane
         LogMenuEvent($"ForceImmediateRefresh: entries={entries.Count}, inventoryNull={inventory == null}");
     }
 
-    protected override void ForceLayoutRebuild()
+    public new void ForceLayoutRebuild()
     {
         try
         {
@@ -840,21 +840,21 @@ internal sealed class ShadeInventoryPane : InventoryPane
 
         LayoutRebuilder.ForceRebuildLayoutImmediate(selfRect);
 
-        Vector2 selfSize = selfRect.rect.size;
+        Vector2 rootSize = selfRect.rect.size;
         string panelSizeText = panelRoot != null ? FormatVector2(panelRoot.rect.size) : "<null>";
         string contentSizeText = contentRoot != null ? FormatVector2(contentRoot.rect.size) : "<null>";
         string gridSizeText = gridRoot != null ? FormatVector2(gridRoot.rect.size) : "<null>";
 
-        if (selfSize.x < MinRootSizeThreshold || selfSize.y < MinRootSizeThreshold)
+        if (rootSize.x < MinRootSizeThreshold || rootSize.y < MinRootSizeThreshold)
         {
             LogMenuEvent(FormattableString.Invariant(
-                $"ForceLayoutRebuild -> self={FormatVector2(selfSize)}, panel={panelSizeText}, content={contentSizeText}, grid={gridSizeText} (threshold={MinRootSizeThreshold})"));
+                $"ForceLayoutRebuild -> root={FormatVector2(rootSize)}, panel={panelSizeText}, content={contentSizeText}, grid={gridSizeText} (threshold={MinRootSizeThreshold})"));
             LogRectTransformHierarchy(selfRect, $"ShadePaneRoot[{gameObject.name}]");
         }
         else
         {
             LogMenuEvent(FormattableString.Invariant(
-                $"ForceLayoutRebuild -> self={FormatVector2(selfSize)}, panel={panelSizeText}, content={contentSizeText}, grid={gridSizeText}"));
+                $"ForceLayoutRebuild -> root={FormatVector2(rootSize)}, panel={panelSizeText}, content={contentSizeText}, grid={gridSizeText}"));
         }
     }
 

--- a/ShadeInventoryPane.cs
+++ b/ShadeInventoryPane.cs
@@ -571,6 +571,11 @@ internal sealed class ShadeInventoryPane : InventoryPane
         {
         }
 
+        if (changed)
+        {
+            LogMenuEvent(FormattableString.Invariant($"UpdateParentListLabel -> '{displayLabel}'"));
+        }
+
     }
 
     private void SubscribeInput()
@@ -581,7 +586,7 @@ internal sealed class ShadeInventoryPane : InventoryPane
         OnInputDown += () => MoveSelectionVertical(1);
     }
 
-    internal void ConfigureFromTemplate(InventoryPane template)
+    internal void ConfigureFromTemplate(InventoryPane? template)
     {
         if (template == null)
         {
@@ -804,16 +809,8 @@ internal sealed class ShadeInventoryPane : InventoryPane
         LogMenuEvent($"ForceImmediateRefresh: entries={entries.Count}, inventoryNull={inventory == null}");
     }
 
-    public new void ForceLayoutRebuild()
+    public void ForceLayoutRebuild()
     {
-        try
-        {
-            base.ForceLayoutRebuild();
-        }
-        catch
-        {
-        }
-
         EnsureBuilt();
 
         var selfRect = transform as RectTransform;
@@ -1133,7 +1130,7 @@ internal sealed class ShadeInventoryPane : InventoryPane
                 tmp.fontMaterial = tmpMaterial;
             }
 
-            tmp.enableWordWrapping = true;
+            tmp.textWrappingMode = TextWrappingModes.Normal;
             tmp.overflowMode = TextOverflowModes.Overflow;
             tmp.raycastTarget = false;
             tmp.text = string.Empty;
@@ -1883,7 +1880,7 @@ internal static class ShadeInventoryPaneIntegration
             return;
         }
 
-        InventoryPaneListDisplay display = null;
+        InventoryPaneListDisplay? display = null;
         if (PaneListDisplayField != null)
         {
             try
@@ -1940,7 +1937,7 @@ internal static class ShadeInventoryPaneIntegration
             return;
         }
 
-        InventoryPane template = panes.FirstOrDefault(p =>
+        InventoryPane? template = panes.FirstOrDefault(p =>
         {
             if (!p)
             {
@@ -1957,8 +1954,14 @@ internal static class ShadeInventoryPaneIntegration
                  typeName.IndexOf("Crest", StringComparison.OrdinalIgnoreCase) >= 0);
             return matchesName || matchesType;
         }) ?? panes.FirstOrDefault(p => p != null) ?? panes[0];
-        var templateRect = template.GetComponent<RectTransform>();
-        var parent = templateRect != null ? templateRect.parent : template.transform.parent;
+        RectTransform? templateRect = null;
+        Transform? parent = null;
+        if (template != null)
+        {
+            templateRect = template.GetComponent<RectTransform>();
+            parent = templateRect != null ? templateRect.parent : template.transform.parent;
+        }
+        parent ??= paneList.transform;
         ShadeInventoryPane.LogMenuEvent($"Injecting shade pane using template '{template?.GetType().Name ?? "<null>"}'");
 
         var go = new GameObject("ShadeInventoryPane", typeof(RectTransform));


### PR DESCRIPTION
## Summary
- add reusable helpers to log RectTransform hierarchies and layout-related components
- extend ForceLayoutRebuild to dump ancestor layout data when the pane root stays below the size threshold
- copy RectTransform and layout component settings from the template pane during injection and log the template hierarchy for comparison

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cedc53f6148320aab9400b4d9b310f