### PR TITLE
Fix shade controller bindings for pause/menu usage and persistence

### DIFF
--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -1,8 +1,6 @@
 #nullable disable
 using System;
 using System.Collections;
-using System.Reflection;
-using GlobalEnums;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -213,107 +211,12 @@ public partial class SimpleHUD : MonoBehaviour
     {
         try
         {
-            if (ShadeSettingsMenu.IsShowing)
-            {
-                return true;
-            }
+            return MenuStateUtility.IsMenuActive();
         }
         catch
-        {
-        }
-
-        try
-        {
-            var gm = GameManager.instance;
-            if (gm != null && gm.IsGamePaused())
-            {
-                return true;
-            }
-        }
-        catch
-        {
-        }
-
-        if (Time.timeScale <= 0.0001f)
-        {
-            return true;
-        }
-
-        try
-        {
-            var ui = UIManager.instance;
-            var state = TryGetUiState(ui);
-            if (state.HasValue && IsMenuState(state.Value))
-            {
-                return true;
-            }
-        }
-        catch
-        {
-        }
-
-        return false;
-    }
-
-    private static UIState? TryGetUiState(UIManager ui)
-    {
-        if (ui == null)
-        {
-            return null;
-        }
-
-        try
-        {
-            return ui.uiState;
-        }
-        catch
-        {
-            try
-            {
-                var field = typeof(UIManager).GetField("uiState", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                if (field != null)
-                {
-                    object value = field.GetValue(ui);
-                    if (value is UIState state)
-                    {
-                        return state;
-                    }
-
-                    if (value is int raw)
-                    {
-                        return (UIState)raw;
-                    }
-                }
-            }
-            catch
-            {
-            }
-        }
-
-        return null;
-    }
-
-    private static bool IsMenuState(UIState state)
-    {
-        string name = state.ToString();
-        if (string.IsNullOrEmpty(name))
         {
             return false;
         }
-
-        if (string.Equals(name, "PLAYING", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(name, "GAMEPLAY", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return name.IndexOf("PAUSE", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               name.IndexOf("MENU", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               name.IndexOf("INVENTORY", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               name.IndexOf("MAP", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               name.IndexOf("JOURNAL", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               name.IndexOf("SHOP", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               name.IndexOf("OPTION", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private void UpdateMenuOrientation(bool menuActive)

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -480,7 +480,7 @@ public partial class LegacyHelper
         }
     }
 
-    private static class InputDeviceBlocker
+    internal static class InputDeviceBlocker
     {
         private static readonly HashSet<InputDevice> restrictedShadeDevices = new();
         private static readonly List<InputDevice> cleanupList = new();
@@ -564,30 +564,21 @@ public partial class LegacyHelper
         {
             try
             {
-                var gm = GameManager.instance;
-                if (gm == null)
-                    return false;
-
-                if (gm.GameState != GameState.PLAYING)
-                    return false;
-
-                UIManager ui = null;
-                try { ui = UIManager.instance; } catch { }
-                if (ui == null)
+                var gm = MenuStateUtility.TryGetGameManager();
+                if (ReferenceEquals(gm, null))
                 {
-                    try { ui = gm.ui; } catch { }
+                    return false;
                 }
 
-                if (ui != null)
+                if (gm.GameState != GameState.PLAYING)
                 {
-                    try
-                    {
-                        if (ui.uiState != UIState.PLAYING)
-                            return false;
-                    }
-                    catch
-                    {
-                    }
+                    return false;
+                }
+
+                var ui = MenuStateUtility.TryGetUiManager(gm);
+                if (MenuStateUtility.IsMenuActive(gm, ui))
+                {
+                    return false;
                 }
 
                 return true;

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -461,7 +461,17 @@ public partial class LegacyHelper
             try
             {
                 var cfg = ModConfig.Instance;
-                return cfg == null || cfg.hornetControllerEnabled;
+                if (cfg == null)
+                    return true;
+
+                if (cfg.hornetControllerEnabled)
+                    return true;
+
+                var shadeConfig = cfg.shadeInput;
+                if (shadeConfig != null && shadeConfig.UsesControllerBindings())
+                    return true;
+
+                return false;
             }
             catch
             {
@@ -557,7 +567,30 @@ public partial class LegacyHelper
                 var gm = GameManager.instance;
                 if (gm == null)
                     return false;
-                return gm.GameState == GameState.PLAYING;
+
+                if (gm.GameState != GameState.PLAYING)
+                    return false;
+
+                UIManager ui = null;
+                try { ui = UIManager.instance; } catch { }
+                if (ui == null)
+                {
+                    try { ui = gm.ui; } catch { }
+                }
+
+                if (ui != null)
+                {
+                    try
+                    {
+                        if (ui.uiState != UIState.PLAYING)
+                            return false;
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                return true;
             }
             catch
             {

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -683,8 +683,14 @@ public partial class LegacyHelper
                 restrict = false;
             }
 
-            SetDeviceRestricted(device, restrict);
-            return restrict && ShouldBlockShadeDeviceInput();
+            bool block = false;
+            if (restrict)
+            {
+                block = ShouldBlockShadeDeviceInput();
+            }
+
+            SetDeviceRestricted(device, block);
+            return block;
         }
 
         internal static void ReleaseDevice(InputHandler handler, InputDevice device)

--- a/MenuStateUtility.cs
+++ b/MenuStateUtility.cs
@@ -3,6 +3,7 @@ using System;
 using System.Reflection;
 using GlobalEnums;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 internal static class MenuStateUtility
 {
@@ -183,6 +184,26 @@ internal static class MenuStateUtility
         if (IsMenuStateName(stateName))
         {
             return true;
+        }
+
+        try
+        {
+            var eventSystem = EventSystem.current;
+            if (eventSystem != null)
+            {
+                var selected = eventSystem.currentSelectedGameObject;
+                if (selected != null && selected.activeInHierarchy)
+                {
+                    var canvas = selected.GetComponentInParent<Canvas>();
+                    if (canvas != null && canvas.isActiveAndEnabled)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        catch
+        {
         }
 
         return false;

--- a/MenuStateUtility.cs
+++ b/MenuStateUtility.cs
@@ -1,0 +1,259 @@
+#nullable disable
+using System;
+using System.Reflection;
+using GlobalEnums;
+using UnityEngine;
+
+internal static class MenuStateUtility
+{
+    internal static GameManager TryGetGameManager()
+    {
+        try
+        {
+            var gm = GameManager.UnsafeInstance;
+            if (!ReferenceEquals(gm, null))
+            {
+                return gm;
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            var field = typeof(GameManager).GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic);
+            if (field != null)
+            {
+                var value = field.GetValue(null) as GameManager;
+                if (!ReferenceEquals(value, null))
+                {
+                    return value;
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            var gm = GameManager.instance;
+            if (!ReferenceEquals(gm, null))
+            {
+                return gm;
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    internal static UIManager TryGetUiManager(GameManager gm)
+    {
+        try
+        {
+            if (!ReferenceEquals(gm, null))
+            {
+                var manager = gm.ui;
+                if (!ReferenceEquals(manager, null))
+                {
+                    return manager;
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            var field = typeof(UIManager).GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic);
+            if (field != null)
+            {
+                var value = field.GetValue(null) as UIManager;
+                if (!ReferenceEquals(value, null))
+                {
+                    return value;
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            var ui = UIManager.instance;
+            if (!ReferenceEquals(ui, null))
+            {
+                return ui;
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    internal static bool IsMenuActive(GameManager gm = null, UIManager ui = null)
+    {
+        try
+        {
+            if (ShadeSettingsMenu.IsShowing)
+            {
+                return true;
+            }
+        }
+        catch
+        {
+        }
+
+        if (ReferenceEquals(gm, null))
+        {
+            gm = TryGetGameManager();
+        }
+
+        if (!ReferenceEquals(gm, null))
+        {
+            try
+            {
+                if (gm.IsGamePaused())
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        if (Time.timeScale <= 0.0001f)
+        {
+            return true;
+        }
+
+        if (ReferenceEquals(ui, null))
+        {
+            ui = TryGetUiManager(gm);
+        }
+
+        string stateName = TryGetUiStateName(ui);
+        if (IsMenuStateName(stateName))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static string TryGetUiStateName(UIManager ui)
+    {
+        if (ReferenceEquals(ui, null))
+        {
+            return null;
+        }
+
+        try
+        {
+            var type = ui.GetType();
+            while (type != null)
+            {
+                var field = type.GetField("uiState", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                if (field != null)
+                {
+                    return ConvertStateValueToName(field.GetValue(ui));
+                }
+                type = type.BaseType;
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            var type = ui.GetType();
+            while (type != null)
+            {
+                var property = type.GetProperty("uiState", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                if (property != null && property.GetIndexParameters().Length == 0)
+                {
+                    return ConvertStateValueToName(property.GetValue(ui, null));
+                }
+                type = type.BaseType;
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    private static string ConvertStateValueToName(object value)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            if (value is string str)
+            {
+                return str;
+            }
+
+            if (value is UIState state)
+            {
+                return state.ToString();
+            }
+
+            if (value is Enum enumValue)
+            {
+                return enumValue.ToString();
+            }
+
+            if (value is int raw)
+            {
+                return ((UIState)raw).ToString();
+            }
+        }
+        catch
+        {
+        }
+
+        return value.ToString();
+    }
+
+    internal static bool IsMenuState(UIState state)
+    {
+        return IsMenuStateName(state.ToString());
+    }
+
+    internal static bool IsMenuStateName(string stateName)
+    {
+        if (string.IsNullOrEmpty(stateName))
+        {
+            return false;
+        }
+
+        if (string.Equals(stateName, "PLAYING", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(stateName, "GAMEPLAY", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return stateName.IndexOf("PAUSE", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               stateName.IndexOf("MENU", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               stateName.IndexOf("INVENTORY", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               stateName.IndexOf("MAP", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               stateName.IndexOf("JOURNAL", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               stateName.IndexOf("SHOP", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               stateName.IndexOf("OPTION", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+}

--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -153,8 +153,11 @@ public class ModConfig
                 Directory.CreateDirectory(directory);
             }
 
-            string json = Serialize(Instance);
-            File.WriteAllText(ModPaths.Config, json);
+            using (LegacyHelper.InputDeviceBlocker.CreateSaveScope())
+            {
+                string json = Serialize(Instance);
+                File.WriteAllText(ModPaths.Config, json);
+            }
         }
         catch
         {

--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -163,12 +163,24 @@ public class ModConfig
 
     private static string Serialize(ModConfig config)
     {
-        if (TrySerializeWithUnity(config, out var json))
+        try
         {
-            return json;
+            string json = JsonConvert.SerializeObject(config, FallbackJsonSettings);
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                return json;
+            }
+        }
+        catch
+        {
         }
 
-        return JsonConvert.SerializeObject(config, FallbackJsonSettings);
+        if (TrySerializeWithUnity(config, out var unityJson))
+        {
+            return unityJson;
+        }
+
+        return string.Empty;
     }
 
     private static bool TrySerializeWithUnity(ModConfig config, out string json)
@@ -196,19 +208,24 @@ public class ModConfig
             return null;
         }
 
-        if (TryDeserializeWithUnity(json, out var config))
-        {
-            return config;
-        }
-
         try
         {
-            return JsonConvert.DeserializeObject<ModConfig>(json, FallbackJsonSettings);
+            var config = JsonConvert.DeserializeObject<ModConfig>(json, FallbackJsonSettings);
+            if (config != null)
+            {
+                return config;
+            }
         }
         catch
         {
-            return null;
         }
+
+        if (TryDeserializeWithUnity(json, out var unityConfig))
+        {
+            return unityConfig;
+        }
+
+        return null;
     }
 
     private static bool TryDeserializeWithUnity(string json, out ModConfig? config)

--- a/ShadeInputConfig.cs
+++ b/ShadeInputConfig.cs
@@ -313,6 +313,52 @@ public class ShadeInputConfig
         else
             binding.primary = option;
     }
+
+    private static ShadeBinding CloneBinding(ShadeBinding binding)
+    {
+        return binding != null ? binding.Clone() : new ShadeBinding();
+    }
+
+    public ShadeInputConfig Clone()
+    {
+        var clone = new ShadeInputConfig();
+        clone.controllerDeviceIndex = controllerDeviceIndex;
+        clone.controllerDeadzone = controllerDeadzone;
+        clone.moveLeft = CloneBinding(moveLeft);
+        clone.moveRight = CloneBinding(moveRight);
+        clone.moveUp = CloneBinding(moveUp);
+        clone.moveDown = CloneBinding(moveDown);
+        clone.fire = CloneBinding(fire);
+        clone.nail = CloneBinding(nail);
+        clone.nailUp = CloneBinding(nailUp);
+        clone.nailDown = CloneBinding(nailDown);
+        clone.teleport = CloneBinding(teleport);
+        clone.focus = CloneBinding(focus);
+        clone.sprint = CloneBinding(sprint);
+        clone.assistMode = CloneBinding(assistMode);
+        return clone;
+    }
+
+    public void CopyBindingsFrom(ShadeInputConfig other)
+    {
+        if (other == null)
+            return;
+
+        controllerDeviceIndex = other.controllerDeviceIndex;
+        controllerDeadzone = other.controllerDeadzone;
+        moveLeft = CloneBinding(other.moveLeft);
+        moveRight = CloneBinding(other.moveRight);
+        moveUp = CloneBinding(other.moveUp);
+        moveDown = CloneBinding(other.moveDown);
+        fire = CloneBinding(other.fire);
+        nail = CloneBinding(other.nail);
+        nailUp = CloneBinding(other.nailUp);
+        nailDown = CloneBinding(other.nailDown);
+        teleport = CloneBinding(other.teleport);
+        focus = CloneBinding(other.focus);
+        sprint = CloneBinding(other.sprint);
+        assistMode = CloneBinding(other.assistMode);
+    }
 }
 
 public static class ShadeInput
@@ -418,8 +464,23 @@ public static class ShadeInput
         ConfigInstance.controllerDeviceIndex = index;
     }
 
+    private static bool ShouldSuppressOption(ShadeBindingOption option)
+    {
+        try
+        {
+            return LegacyHelper.InputDeviceBlocker.ShouldSuppressShadeOption(option);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static bool IsOptionHeld(ShadeBindingOption option)
     {
+        if (ShouldSuppressOption(option))
+            return false;
+
         return option.type switch
         {
             ShadeBindingOptionType.Key => option.key != KeyCode.None && Input.GetKey(option.key),
@@ -430,6 +491,9 @@ public static class ShadeInput
 
     private static bool WasOptionPressed(ShadeBindingOption option)
     {
+        if (ShouldSuppressOption(option))
+            return false;
+
         return option.type switch
         {
             ShadeBindingOptionType.Key => option.key != KeyCode.None && Input.GetKeyDown(option.key),
@@ -440,6 +504,9 @@ public static class ShadeInput
 
     private static float GetOptionValue(ShadeBindingOption option)
     {
+        if (ShouldSuppressOption(option))
+            return 0f;
+
         return option.type switch
         {
             ShadeBindingOptionType.Key => option.key != KeyCode.None && Input.GetKey(option.key) ? 1f : 0f,

--- a/Tests/InputDeviceBlockerTests.cs
+++ b/Tests/InputDeviceBlockerTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using GlobalEnums;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using Xunit;
 
 public class InputDeviceBlockerTests
@@ -41,6 +42,39 @@ public class InputDeviceBlockerTests
 
             environment.SetUiState("MapScreen");
             Assert.False(LegacyHelper.InputDeviceBlocker.ShouldBlockShadeDeviceInput());
+
+            environment.SetPaused(false);
+            environment.SetInventoryOpen(false);
+            environment.ClearMenuState();
+            environment.SetUiState(UIState.PLAYING);
+
+            var eventSystemObject = new GameObject("EventSystem", typeof(EventSystem));
+            try
+            {
+                var canvasObject = new GameObject("Canvas", typeof(Canvas));
+                try
+                {
+                    var selection = new GameObject("Selection");
+                    selection.transform.SetParent(canvasObject.transform, false);
+                    EventSystem.current?.SetSelectedGameObject(selection);
+
+                    Assert.False(LegacyHelper.InputDeviceBlocker.ShouldBlockShadeDeviceInput());
+
+                    UnityEngine.Object.DestroyImmediate(selection);
+                }
+                finally
+                {
+                    UnityEngine.Object.DestroyImmediate(canvasObject);
+                }
+            }
+            finally
+            {
+                if (EventSystem.current != null)
+                {
+                    EventSystem.current.SetSelectedGameObject(null);
+                }
+                UnityEngine.Object.DestroyImmediate(eventSystemObject);
+            }
         }
     }
 

--- a/Tests/InputDeviceBlockerTests.cs
+++ b/Tests/InputDeviceBlockerTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using GlobalEnums;
+using UnityEngine;
+using Xunit;
+
+public class InputDeviceBlockerTests
+{
+    [Fact]
+    public void AllowsShadeControllerInMenuStates()
+    {
+        using (var environment = new InputBlockerEnvironment())
+        {
+            environment.SetUiState(UIState.PLAYING);
+            Assert.True(LegacyHelper.InputDeviceBlocker.ShouldBlockShadeDeviceInput());
+
+            environment.SetUiState("inventory_overlay");
+            Assert.False(LegacyHelper.InputDeviceBlocker.ShouldBlockShadeDeviceInput());
+
+            environment.SetUiState("MapScreen");
+            Assert.False(LegacyHelper.InputDeviceBlocker.ShouldBlockShadeDeviceInput());
+        }
+    }
+
+    private sealed class InputBlockerEnvironment : IDisposable
+    {
+        private readonly object originalGameManager;
+        private readonly object originalUiManager;
+        private readonly float originalTimeScale;
+        private readonly GameManager gm;
+        private readonly TestUIManager ui;
+
+        internal InputBlockerEnvironment()
+        {
+            originalGameManager = GetStaticField(typeof(GameManager), "_instance");
+            originalUiManager = GetStaticField(typeof(UIManager), "_instance");
+            originalTimeScale = Time.timeScale;
+
+            gm = (GameManager)FormatterServices.GetUninitializedObject(typeof(GameManager));
+            ui = (TestUIManager)FormatterServices.GetUninitializedObject(typeof(TestUIManager));
+
+            SetProperty(gm, "GameState", GameState.PLAYING);
+            SetProperty(gm, "ui", ui);
+
+            SetStaticField(typeof(GameManager), "_instance", gm);
+            SetStaticField(typeof(UIManager), "_instance", ui);
+
+            Time.timeScale = 1f;
+        }
+
+        internal void SetUiState(UIState state)
+        {
+            ui.uiState = state;
+        }
+
+        internal void SetUiState(string stateName)
+        {
+            ui.uiState = stateName;
+        }
+
+        public void Dispose()
+        {
+            SetStaticField(typeof(GameManager), "_instance", originalGameManager);
+            SetStaticField(typeof(UIManager), "_instance", originalUiManager);
+            Time.timeScale = originalTimeScale;
+        }
+
+        private static object GetStaticField(Type type, string name)
+        {
+            var field = type.GetField(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            return field?.GetValue(null);
+        }
+
+        private static void SetStaticField(Type type, string name, object value)
+        {
+            var field = type.GetField(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            field?.SetValue(null, value);
+        }
+
+        private static void SetProperty(object target, string name, object value)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            var property = target.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            property?.SetValue(target, value, null);
+        }
+
+        private sealed class TestUIManager : UIManager
+        {
+            public new object uiState;
+        }
+    }
+}

--- a/Tests/ModConfigTests.cs
+++ b/Tests/ModConfigTests.cs
@@ -1,3 +1,4 @@
+using InControl;
 using UnityEngine;
 using Xunit;
 
@@ -27,7 +28,7 @@ public class ModConfigTests
         Assert.False(loaded.shadeEnabled);
         loaded.shadeEnabled = true;
         ModConfig.Save();
-}
+    }
 
     [Fact]
     public void ShadeBindingRebindPersists()
@@ -41,5 +42,31 @@ public class ModConfigTests
         var binding = loaded.shadeInput.GetBinding(ShadeAction.Nail);
         Assert.Equal(ShadeBindingOptionType.Key, binding.primary.type);
         Assert.Equal(KeyCode.P, binding.primary.key);
+    }
+
+    [Fact]
+    public void ShadeControllerBindingPersists()
+    {
+        var cfg = ModConfig.Instance;
+        cfg.shadeInput.ResetToDefaults();
+        cfg.shadeInput.controllerDeviceIndex = 2;
+        cfg.shadeInput.SetBindingOption(ShadeAction.MoveLeft, false, ShadeBindingOption.FromControl(InputControlType.LeftStickLeft, 1));
+        cfg.shadeInput.SetBindingOption(ShadeAction.Focus, true, ShadeBindingOption.FromControl(InputControlType.RightTrigger));
+        ModConfig.Save();
+        var loaded = ModConfig.Load();
+
+        Assert.Equal(2, loaded.shadeInput.controllerDeviceIndex);
+
+        var moveLeft = loaded.shadeInput.GetBinding(ShadeAction.MoveLeft);
+        Assert.NotNull(moveLeft);
+        Assert.Equal(ShadeBindingOptionType.Controller, moveLeft.primary.type);
+        Assert.Equal(InputControlType.LeftStickLeft, moveLeft.primary.control);
+        Assert.Equal(1, moveLeft.primary.controllerDevice);
+
+        var focus = loaded.shadeInput.GetBinding(ShadeAction.Focus);
+        Assert.NotNull(focus);
+        Assert.Equal(ShadeBindingOptionType.Controller, focus.secondary.type);
+        Assert.Equal(InputControlType.RightTrigger, focus.secondary.control);
+        Assert.Equal(-1, focus.secondary.controllerDevice);
     }
 }


### PR DESCRIPTION
## Summary
- allow the base game to map controller buttons when the shade is using a pad so pause and inventory shortcuts stay active
- stop blocking shade-controlled devices while menus are showing by checking the UI state before ignoring input
- switch config serialization to Json.NET so shade controller bindings persist and cover this with a controller persistence test

## Testing
- dotnet test -c Release *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1925cff588320b684f1ae837319c9