### PR TITLE
Fix shade menu placeholder detection

### DIFF
--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -928,6 +928,11 @@ public partial class LegacyHelper
 
         internal static bool IsShadePlaceholderBinding(BindingSource binding)
         {
+            if (binding is ShadeMenuBindingSourceBase)
+            {
+                return true;
+            }
+
             return IsPlaceholderBinding(binding);
         }
 


### PR DESCRIPTION
## Summary
- treat shade menu binding sources as placeholders when evaluating key bindings
- prevent InputHandler from logging errors about null bindings for the shade inventory action

## Testing
- `dotnet test -c Release` *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d410b2b7848320bb4b6d297fdf16e0