### PR TITLE
Add shade lifeblood system and charm fixes

### DIFF
--- a/HUD.Data.cs
+++ b/HUD.Data.cs
@@ -9,17 +9,21 @@ public partial class SimpleHUD
         {
             shadeMax = 0;
             shadeHealth = 0;
+            shadeLifebloodMax = 0;
+            shadeLifeblood = 0;
             prevHornetMax = 0;
             prevHornetHealth = 0;
             suppressNextDamageSound = false;
             return;
         }
         shadeMax = (playerData.maxHealth + 1) / 2;
+        shadeLifebloodMax = 0;
         prevHornetMax = playerData.maxHealth;
         prevHornetHealth = playerData.health;
         if (!hasExplicitShadeStats)
         {
             shadeHealth = (playerData.health + 1) / 2;
+            shadeLifeblood = 0;
             suppressNextDamageSound = true;
         }
     }
@@ -32,7 +36,10 @@ public partial class SimpleHUD
         int newMax = (newHornetMax + 1) / 2;
         if (newMax != shadeMax)
         {
-            shadeMax = newMax; RebuildMasks(); previousShadeHealth = Mathf.Min(previousShadeHealth, shadeMax); shadeHealth = Mathf.Min(shadeHealth, shadeMax);
+            shadeMax = newMax;
+            RebuildMasks();
+            previousShadeTotalHealth = Mathf.Min(previousShadeTotalHealth, shadeMax + shadeLifebloodMax);
+            shadeHealth = Mathf.Min(shadeHealth, shadeMax);
         }
         prevHornetHealth = newHornet; prevHornetMax = newHornetMax;
     }

--- a/LegacyHelper.Core.cs
+++ b/LegacyHelper.Core.cs
@@ -24,9 +24,9 @@ public partial class LegacyHelper : BaseUnityPlugin
     // Persist shade state across scene transitions
     internal static bool HasSavedShadeState => ShadeRuntime.PersistentState.HasData;
 
-    internal static void SaveShadeState(int curHp, int maxHp, int soul, bool? canTakeDamage = null)
+    internal static void SaveShadeState(int curHp, int maxHp, int lifebloodCur, int lifebloodMax, int soul, bool? canTakeDamage = null)
     {
-        ShadeRuntime.CaptureState(curHp, maxHp, soul, canTakeDamage);
+        ShadeRuntime.CaptureState(curHp, maxHp, lifebloodCur, lifebloodMax, soul, canTakeDamage);
     }
 
     // Called when Hornet gains a new spell. Advances Shade's unlock/upgrade track.
@@ -180,7 +180,7 @@ public partial class LegacyHelper : BaseUnityPlugin
                     sc.SuppressHazardDamage(SceneSpawnProtectionSeconds);
                     sc.ApplySceneTransitionProtection(SceneSpawnProtectionSeconds);
                     sc.TriggerSpawnEntrance();
-                    SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
+                    SaveShadeState(sc.GetCurrentNormalHP(), sc.GetMaxNormalHP(), sc.GetCurrentLifeblood(), sc.GetMaxLifeblood(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
                     RequestShadeLoadoutRecompute();
                 }
                 else
@@ -199,9 +199,9 @@ public partial class LegacyHelper : BaseUnityPlugin
 
         var scNew = helper.AddComponent<ShadeController>();
         scNew.Init(gm.hero_ctrl.transform);
-        if (ShadeRuntime.TryGetPersistentState(out var savedHp, out var savedMax, out var savedSoul, out var savedCanTakeDamage))
+        if (ShadeRuntime.TryGetPersistentState(out var savedHp, out var savedMax, out var savedLifeblood, out var savedLifebloodMax, out var savedSoul, out var savedCanTakeDamage))
         {
-            scNew.RestorePersistentState(savedHp, savedMax, savedSoul, savedCanTakeDamage);
+            scNew.RestorePersistentState(savedHp, savedMax, savedLifeblood, savedLifebloodMax, savedSoul, savedCanTakeDamage);
         }
 
         scNew.SuppressHazardDamage(SceneSpawnProtectionSeconds);

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -78,7 +78,7 @@ public partial class LegacyHelper
                     if (sc != null)
                     {
                         sc.ReviveToAtLeast(1);
-                        SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
+                        SaveShadeState(sc.GetCurrentNormalHP(), sc.GetMaxNormalHP(), sc.GetCurrentLifeblood(), sc.GetMaxLifeblood(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
                         return;
                     }
                 }
@@ -354,7 +354,7 @@ public partial class LegacyHelper
                     if (sc != null)
                     {
                         sc.FullHealFromBench();
-                        SaveShadeState(sc.GetCurrentHP(), sc.GetMaxHP(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
+                        SaveShadeState(sc.GetCurrentNormalHP(), sc.GetMaxNormalHP(), sc.GetCurrentLifeblood(), sc.GetMaxLifeblood(), sc.GetShadeSoul(), sc.GetCanTakeDamage());
                     }
                 }
             }

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -36,6 +36,10 @@ public partial class LegacyHelper
         private Collider2D bodyCol;
         private int shadeMaxHP;
         private int shadeHP;
+        private int shadeLifeblood;
+        private int shadeLifebloodMax;
+        private int pendingRestoredLifeblood = -1;
+        private int pendingRestoredLifebloodMax = -1;
         private float hazardCooldown;
         private float baseMaxDistance, baseSoftLeashRadius, baseHardLeashRadius, baseSnapLeashRadius;
         private float baseSprintMultiplier;
@@ -217,6 +221,9 @@ public partial class LegacyHelper
         private float charmHurtIFrameMultiplier = 1f;
         private float currentHurtIFrameDuration = HurtIFrameSeconds;
         private int charmMaxHpBonus;
+        private int charmLifebloodBonus;
+        private bool jonisBlessingEquipped;
+        private bool hivebloodPendingLifebloodRestore;
         private bool allowFocusMovement;
         private int knockbackSuppressionCount;
         private readonly Dictionary<string, float> conditionalNailDamageMultipliers = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
@@ -232,6 +239,8 @@ public partial class LegacyHelper
 
         private int lastSavedHP;
         private int lastSavedMax;
+        private int lastSavedLifeblood;
+        private int lastSavedLifebloodMax;
         private int lastSavedSoul;
         private bool lastSavedCanTakeDamage = true;
     }

--- a/LegacyHelper.ShadeController.Persistence.cs
+++ b/LegacyHelper.ShadeController.Persistence.cs
@@ -6,10 +6,14 @@ public partial class LegacyHelper
 {
     public partial class ShadeController
     {
-        public void RestorePersistentState(int hp, int max, int soul, bool canDamage = true)
+        public void RestorePersistentState(int hp, int max, int lifeblood, int lifebloodMax, int soul, bool canDamage = true)
         {
-            shadeMaxHP = Mathf.Max(1, max);
+            shadeMaxHP = Mathf.Max(0, max);
             shadeHP = Mathf.Clamp(hp, 0, shadeMaxHP);
+            pendingRestoredLifebloodMax = Mathf.Max(0, lifebloodMax);
+            pendingRestoredLifeblood = Mathf.Clamp(lifeblood, 0, pendingRestoredLifebloodMax);
+            shadeLifebloodMax = pendingRestoredLifebloodMax;
+            shadeLifeblood = pendingRestoredLifeblood;
             shadeSoul = Mathf.Clamp(soul, 0, shadeSoulMax);
             canTakeDamage = canDamage;
             lastSavedCanTakeDamage = canTakeDamage;
@@ -17,8 +21,11 @@ public partial class LegacyHelper
 
         public void FullHealFromBench()
         {
-            shadeHP = Mathf.Max(shadeHP, shadeMaxHP);
-            if (shadeHP > 0)
+            ApplyCharmHealthModifiers(refillLifeblood: true);
+            shadeHP = shadeMaxHP;
+            shadeLifeblood = shadeLifebloodMax;
+            hivebloodPendingLifebloodRestore = false;
+            if (GetTotalCurrentHealth() > 0)
             {
                 isInactive = false;
                 CancelDeathAnimation();
@@ -27,11 +34,19 @@ public partial class LegacyHelper
             PushShadeStatsToHud();
         }
 
-        public void ReviveToAtLeast(int hp)
+        public void ReviveToAtLeast(int hp, bool allowLifeblood = false)
         {
-            int target = Mathf.Max(1, hp);
-            shadeHP = Mathf.Max(shadeHP, target);
-            if (shadeHP > 0)
+            int target = Mathf.Max(0, hp);
+            shadeHP = Mathf.Clamp(Mathf.Max(shadeHP, target), 0, shadeMaxHP);
+
+            if (allowLifeblood && shadeHP < target && shadeLifeblood < shadeLifebloodMax)
+            {
+                int deficit = Mathf.Max(0, target - shadeHP);
+                int toRestore = Mathf.Min(deficit, shadeLifebloodMax - shadeLifeblood);
+                shadeLifeblood += toRestore;
+            }
+
+            if (GetTotalCurrentHealth() > 0)
             {
                 isInactive = false;
                 CancelDeathAnimation();
@@ -40,8 +55,12 @@ public partial class LegacyHelper
             PersistIfChanged();
         }
 
-        public int GetCurrentHP() => shadeHP;
-        public int GetMaxHP() => shadeMaxHP;
+        public int GetCurrentHP() => Mathf.Max(0, shadeHP) + Mathf.Max(0, shadeLifeblood);
+        public int GetCurrentNormalHP() => Mathf.Max(0, shadeHP);
+        public int GetMaxHP() => Mathf.Max(0, shadeMaxHP) + Mathf.Max(0, shadeLifebloodMax);
+        public int GetMaxNormalHP() => Mathf.Max(0, shadeMaxHP);
+        public int GetCurrentLifeblood() => Mathf.Max(0, shadeLifeblood);
+        public int GetMaxLifeblood() => Mathf.Max(0, shadeLifebloodMax);
         public int GetShadeSoul() => shadeSoul;
         public int GetShadeSoulMax() => shadeSoulMax;
         public bool GetCanTakeDamage() => canTakeDamage;
@@ -50,10 +69,20 @@ public partial class LegacyHelper
 
         private void PersistIfChanged()
         {
-            if (lastSavedHP != shadeHP || lastSavedMax != shadeMaxHP || lastSavedSoul != shadeSoul || lastSavedCanTakeDamage != canTakeDamage)
+            if (lastSavedHP != shadeHP
+                || lastSavedMax != shadeMaxHP
+                || lastSavedLifeblood != shadeLifeblood
+                || lastSavedLifebloodMax != shadeLifebloodMax
+                || lastSavedSoul != shadeSoul
+                || lastSavedCanTakeDamage != canTakeDamage)
             {
-                LegacyHelper.SaveShadeState(shadeHP, shadeMaxHP, shadeSoul, canTakeDamage);
-                lastSavedHP = shadeHP; lastSavedMax = shadeMaxHP; lastSavedSoul = shadeSoul; lastSavedCanTakeDamage = canTakeDamage;
+                LegacyHelper.SaveShadeState(shadeHP, shadeMaxHP, shadeLifeblood, shadeLifebloodMax, shadeSoul, canTakeDamage);
+                lastSavedHP = shadeHP;
+                lastSavedMax = shadeMaxHP;
+                lastSavedLifeblood = shadeLifeblood;
+                lastSavedLifebloodMax = shadeLifebloodMax;
+                lastSavedSoul = shadeSoul;
+                lastSavedCanTakeDamage = canTakeDamage;
             }
         }
 
@@ -71,13 +100,18 @@ public partial class LegacyHelper
             {
                 try
                 {
-                    cachedHud.SetShadeStats(shadeHP, shadeMaxHP);
+                    cachedHud.SetShadeStats(shadeHP, shadeMaxHP, shadeLifeblood, shadeLifebloodMax);
                     cachedHud.SetShadeOvercharmed(ShadeRuntime.Charms?.IsOvercharmed ?? false);
                 }
                 catch
                 {
                 }
             }
+        }
+
+        private int GetTotalCurrentHealth()
+        {
+            return Mathf.Max(0, shadeHP) + Mathf.Max(0, shadeLifeblood);
         }
     }
 }

--- a/Shade/ShadeCharmInventory.cs
+++ b/Shade/ShadeCharmInventory.cs
@@ -158,20 +158,6 @@ namespace LegacyoftheAbyss.Shade
                 iconName: "shade_charm_soul_catcher"));
 
             _definitions.Add(new ShadeCharmDefinition(
-                nameof(ShadeCharmId.FragileStrength),
-                hooks: new ShadeCharmHooks
-                {
-                    OnApplied = ctx => ctx.Controller?.MultiplyNailDamage(1.5f),
-                    OnRemoved = ctx => ctx.Controller?.MultiplyNailDamage(1f / 1.5f)
-                },
-                displayName: "Fragile Strength",
-                description: "Strengthens the bearer, allowing them to deal more damage to foes. If its bearer is killed, this charm will break.",
-                notchCost: 3,
-                fallbackTint: new Color(0.82f, 0.52f, 0.18f),
-                enumId: ShadeCharmId.FragileStrength,
-                iconName: "shade_charm_fragile_strength"));
-
-            _definitions.Add(new ShadeCharmDefinition(
                 nameof(ShadeCharmId.SoulEater),
                 hooks: new ShadeCharmHooks
                 {
@@ -363,6 +349,34 @@ namespace LegacyoftheAbyss.Shade
                 enumId: ShadeCharmId.FragileHeart,
                 iconName: "shade_charm_fragile_heart"));
 
+            _definitions.Add(new ShadeCharmDefinition(
+                nameof(ShadeCharmId.FragileGreed),
+                hooks: new ShadeCharmHooks
+                {
+                    OnApplied = ctx => ctx.Controller?.AddSoulGainBonus(8),
+                    OnRemoved = ctx => ctx.Controller?.AddSoulGainBonus(-8)
+                },
+                displayName: "Fragile Greed",
+                description: "Fills the bearer with a desire to reap every scrap of SOUL. Increases SOUL gained from attacks, but will shatter if the shade is defeated.",
+                notchCost: 2,
+                fallbackTint: new Color(0.90f, 0.78f, 0.32f),
+                enumId: ShadeCharmId.FragileGreed,
+                iconName: "shade_charm_fragile_greed"));
+
+            _definitions.Add(new ShadeCharmDefinition(
+                nameof(ShadeCharmId.FragileStrength),
+                hooks: new ShadeCharmHooks
+                {
+                    OnApplied = ctx => ctx.Controller?.MultiplyNailDamage(1.5f),
+                    OnRemoved = ctx => ctx.Controller?.MultiplyNailDamage(1f / 1.5f)
+                },
+                displayName: "Fragile Strength",
+                description: "Strengthens the bearer, allowing them to deal more damage to foes. If its bearer is killed, this charm will break.",
+                notchCost: 3,
+                fallbackTint: new Color(0.82f, 0.52f, 0.18f),
+                enumId: ShadeCharmId.FragileStrength,
+                iconName: "shade_charm_fragile_strength"));
+
             // TODO: Empower the shade's teleport to damage foes and extend its reach for Sharp Shadow.
             _definitions.Add(new ShadeCharmDefinition(
                 nameof(ShadeCharmId.SharpShadow),
@@ -411,20 +425,6 @@ namespace LegacyoftheAbyss.Shade
                 iconName: "shade_charm_grubberflys_elegy"));
 
             _definitions.Add(new ShadeCharmDefinition(
-                nameof(ShadeCharmId.FragileGreed),
-                hooks: new ShadeCharmHooks
-                {
-                    OnApplied = ctx => ctx.Controller?.AddSoulGainBonus(8),
-                    OnRemoved = ctx => ctx.Controller?.AddSoulGainBonus(-8)
-                },
-                displayName: "Fragile Greed",
-                description: "Fills the bearer with a desire to reap every scrap of SOUL. Increases SOUL gained from attacks, but will shatter if the shade is defeated.",
-                notchCost: 2,
-                fallbackTint: new Color(0.90f, 0.78f, 0.32f),
-                enumId: ShadeCharmId.FragileGreed,
-                iconName: "shade_charm_fragile_greed"));
-
-            _definitions.Add(new ShadeCharmDefinition(
                 nameof(ShadeCharmId.HeavyBlow),
                 hooks: new ShadeCharmHooks
                 {
@@ -456,8 +456,8 @@ namespace LegacyoftheAbyss.Shade
                 nameof(ShadeCharmId.LifebloodHeart),
                 hooks: new ShadeCharmHooks
                 {
-                    OnApplied = ctx => ctx.Controller?.AddMaxHpBonus(2, true),
-                    OnRemoved = ctx => ctx.Controller?.AddMaxHpBonus(-2, false)
+                    OnApplied = ctx => ctx.Controller?.AddLifebloodBonus(2),
+                    OnRemoved = ctx => ctx.Controller?.AddLifebloodBonus(-2)
                 },
                 displayName: "Lifeblood Heart",
                 description: "The shade grows new lifeblood nodes, granting extra vitality that must be renewed at benches.",
@@ -470,8 +470,8 @@ namespace LegacyoftheAbyss.Shade
                 nameof(ShadeCharmId.LifebloodCore),
                 hooks: new ShadeCharmHooks
                 {
-                    OnApplied = ctx => ctx.Controller?.AddMaxHpBonus(4, true),
-                    OnRemoved = ctx => ctx.Controller?.AddMaxHpBonus(-4, false)
+                    OnApplied = ctx => ctx.Controller?.AddLifebloodBonus(4),
+                    OnRemoved = ctx => ctx.Controller?.AddLifebloodBonus(-4)
                 },
                 displayName: "Lifeblood Core",
                 description: "A massive core of lifeblood that courses through the shade, dramatically increasing temporary vitality.",
@@ -487,12 +487,12 @@ namespace LegacyoftheAbyss.Shade
                     OnApplied = ctx =>
                     {
                         ctx.Controller?.SetFocusHealingDisabled(true);
-                        ctx.Controller?.AddMaxHpBonus(6, true);
+                        ctx.Controller?.SetJonisBlessingActive(true);
                     },
                     OnRemoved = ctx =>
                     {
                         ctx.Controller?.SetFocusHealingDisabled(false);
-                        ctx.Controller?.AddMaxHpBonus(-6, false);
+                        ctx.Controller?.SetJonisBlessingActive(false);
                     }
                 },
                 displayName: "Joni's Blessing",
@@ -507,7 +507,11 @@ namespace LegacyoftheAbyss.Shade
                 hooks: new ShadeCharmHooks
                 {
                     OnApplied = ctx => hivebloodTimer = 0f,
-                    OnRemoved = ctx => hivebloodTimer = 0f,
+                    OnRemoved = ctx =>
+                    {
+                        hivebloodTimer = 0f;
+                        ctx.Controller?.ResetHivebloodLifebloodRequest();
+                    },
                     OnShadeDamaged = (ctx, evt) =>
                     {
                         if (evt.ActualDamage > 0 && !evt.WasPrevented)
@@ -523,7 +527,10 @@ namespace LegacyoftheAbyss.Shade
                             return;
                         }
 
-                        if (controller.GetCurrentHP() >= controller.GetMaxHP())
+                        bool missingNormal = controller.GetCurrentNormalHP() < controller.GetMaxNormalHP();
+                        bool pendingLifeblood = controller.ShouldHivebloodRestoreLifeblood();
+
+                        if (!missingNormal && !pendingLifeblood)
                         {
                             hivebloodTimer = 0f;
                             return;
@@ -533,7 +540,14 @@ namespace LegacyoftheAbyss.Shade
                         if (hivebloodTimer >= 10f)
                         {
                             hivebloodTimer = 0f;
-                            controller.ReviveToAtLeast(controller.GetCurrentHP() + 1);
+                            if (missingNormal)
+                            {
+                                controller.ReviveToAtLeast(controller.GetCurrentNormalHP() + 1);
+                            }
+                            else if (pendingLifeblood && controller.TryRestoreLifeblood(1))
+                            {
+                                controller.ResetHivebloodLifebloodRequest();
+                            }
                         }
                     }
                 },

--- a/Shade/ShadeRuntime.cs
+++ b/Shade/ShadeRuntime.cs
@@ -69,12 +69,14 @@ namespace LegacyoftheAbyss.Shade
             }
         }
 
-        public static bool TryGetPersistentState(out int currentHp, out int maxHp, out int soul, out bool canTakeDamage)
+        public static bool TryGetPersistentState(out int currentHp, out int maxHp, out int lifebloodCurrent, out int lifebloodMax, out int soul, out bool canTakeDamage)
         {
             if (!s_persistentState.HasData)
             {
                 currentHp = -1;
                 maxHp = -1;
+                lifebloodCurrent = -1;
+                lifebloodMax = -1;
                 soul = -1;
                 canTakeDamage = true;
                 return false;
@@ -82,14 +84,16 @@ namespace LegacyoftheAbyss.Shade
 
             currentHp = s_persistentState.CurrentHP;
             maxHp = s_persistentState.MaxHP;
+            lifebloodCurrent = s_persistentState.CurrentLifeblood;
+            lifebloodMax = s_persistentState.LifebloodMax;
             soul = s_persistentState.Soul;
             canTakeDamage = s_persistentState.CanTakeDamage;
             return true;
         }
 
-        public static void CaptureState(int currentHp, int maxHp, int soul, bool? canTakeDamage = null)
+        public static void CaptureState(int currentHp, int maxHp, int lifebloodCurrent, int lifebloodMax, int soul, bool? canTakeDamage = null)
         {
-            s_persistentState.Capture(currentHp, maxHp, soul, canTakeDamage);
+            s_persistentState.Capture(currentHp, maxHp, lifebloodCurrent, lifebloodMax, soul, canTakeDamage);
         }
 
         public static void EnsureMinimumHealth(int minimum)

--- a/Tests/ShadePersistenceTests.cs
+++ b/Tests/ShadePersistenceTests.cs
@@ -11,11 +11,13 @@ public class ShadePersistentStateTests
     public void CaptureClampsValues()
     {
         var state = new ShadePersistentState();
-        state.Capture(-10, -5, -20, false);
+        state.Capture(-10, -5, -3, -4, -20, false);
 
         Assert.True(state.HasData);
         Assert.Equal(1, state.MaxHP);
         Assert.Equal(0, state.CurrentHP);
+        Assert.Equal(0, state.LifebloodMax);
+        Assert.Equal(0, state.CurrentLifeblood);
         Assert.Equal(0, state.Soul);
         Assert.False(state.CanTakeDamage);
     }
@@ -24,7 +26,7 @@ public class ShadePersistentStateTests
     public void ForceMinimumHealthRespectsBounds()
     {
         var state = new ShadePersistentState();
-        state.Capture(1, 3, 0, true);
+        state.Capture(1, 3, 0, 0, 0, true);
         state.ForceMinimumHealth(4);
 
         Assert.Equal(3, state.CurrentHP); // clamped to max HP
@@ -151,11 +153,11 @@ public class ShadeSaveSlotRepositoryTests
         WithRepository(repository =>
         {
             var original = new ShadePersistentState();
-            original.Capture(2, 5, 10, false);
+            original.Capture(2, 5, 0, 0, 10, false);
 
             repository.UpdateSlot(1, original);
 
-            original.Capture(1, 3, 1, true);
+            original.Capture(1, 3, 0, 0, 1, true);
             Assert.True(repository.TryGetSlot(1, out var stored));
             Assert.NotSame(original, stored);
             Assert.Equal(2, stored.CurrentHP);
@@ -188,7 +190,7 @@ public class ShadeSaveSlotRepositoryTests
         WithRepository(repository =>
         {
             var slot = repository.GetOrCreateSlot(0);
-            slot.Capture(3, 6, 12, true);
+            slot.Capture(3, 6, 0, 0, 12, true);
 
             var sameSlot = repository.GetOrCreateSlot(0);
             Assert.Same(slot, sameSlot);
@@ -290,7 +292,7 @@ public class ShadeSaveSlotRepositoryTests
         try
         {
             var state = new ShadePersistentState();
-            state.Capture(4, 8, 20, true);
+            state.Capture(4, 8, 0, 0, 20, true);
             state.SetNotchCapacity(5);
             state.UnlockCharm((int)ShadeCharmId.ShamanStone);
             state.EquipCharm(0, (int)ShadeCharmId.ShamanStone);


### PR DESCRIPTION
## Summary
- implement lifeblood health pools for the shade, including Joni's Blessing/Hiveblood behaviour and bench refills
- persist lifeblood stats through the runtime and charm inventory while grouping fragile charms together
- update the HUD and tests so lifeblood masks render distinctly and persistence covers the new values

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4128f2efc832087355fb7d29740dd