### PR TITLE
Handle assist HUD visibility and fury edge cases

### DIFF
--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -43,6 +43,7 @@ public partial class SimpleHUD : MonoBehaviour
     private bool hasExplicitShadeStats;
     private bool shadeOvercharmed;
     private bool suppressNextDamageSound;
+    private bool shadeAssistModeActive;
 
     // UI containers
     private GameObject healthContainer;
@@ -286,6 +287,11 @@ public partial class SimpleHUD : MonoBehaviour
         shadeHealth = newCurNormal;
         shadeLifeblood = newCurLifeblood;
 
+        if (healthContainer != null && healthContainer.activeSelf == shadeAssistModeActive)
+        {
+            healthContainer.SetActive(!shadeAssistModeActive);
+        }
+
         if (firstExplicit)
         {
             previousShadeTotalHealth = shadeHealth + shadeLifeblood;
@@ -298,6 +304,30 @@ public partial class SimpleHUD : MonoBehaviour
         }
 
         RefreshHealth();
+    }
+
+    public void SetShadeAssistMode(bool assistActive)
+    {
+        if (shadeAssistModeActive == assistActive)
+        {
+            if (healthContainer != null && healthContainer.activeSelf == assistActive)
+            {
+                healthContainer.SetActive(!assistActive);
+            }
+            return;
+        }
+
+        shadeAssistModeActive = assistActive;
+        if (healthContainer != null)
+        {
+            healthContainer.SetActive(!assistActive);
+        }
+
+        if (!assistActive)
+        {
+            RebuildMasks();
+            RefreshHealth();
+        }
     }
 
     public void SuppressNextShadeDamageSfx()

--- a/HUD.UI.cs
+++ b/HUD.UI.cs
@@ -113,10 +113,20 @@ public partial class SimpleHUD
         }
         unlockPopup.Initialize(canvas, GetUIScale);
         UpdateMenuOrientation(ShouldTreatAsMenu());
+        SetShadeAssistMode(shadeAssistModeActive);
     }
 
     private void RefreshHealth()
     {
+        if (shadeAssistModeActive)
+        {
+            previousShadeTotalHealth = Mathf.Clamp(
+                shadeHealth + shadeLifeblood,
+                0,
+                Mathf.Max(0, shadeMax) + Mathf.Max(0, shadeLifebloodMax));
+            return;
+        }
+
         if (maskImages == null) return;
 
         int normalMax = Mathf.Max(0, shadeMax);

--- a/LegacyHelper.ShadeController.Persistence.cs
+++ b/LegacyHelper.ShadeController.Persistence.cs
@@ -147,6 +147,7 @@ public partial class LegacyHelper
                     hud.SuppressNextShadeDamageSfx();
                 }
 
+                hud.SetShadeAssistMode(!canTakeDamage);
                 hud.SetShadeStats(shadeHP, shadeMaxHP, shadeLifeblood, shadeLifebloodMax);
                 hud.SetShadeOvercharmed(ShadeRuntime.Charms?.IsOvercharmed ?? false);
             }

--- a/Shade/ShadeCharmInventory.cs
+++ b/Shade/ShadeCharmInventory.cs
@@ -296,7 +296,13 @@ namespace LegacyoftheAbyss.Shade
                             return;
                         }
 
-                        bool shouldBoost = controller.GetCurrentHP() <= 1;
+                        bool nearDeathOnNormalPool = controller.GetCurrentNormalHP() <= 1;
+                        bool hasLifeblood = controller.GetCurrentLifeblood() > 0;
+                        bool alive = controller.GetCurrentHP() > 0;
+                        bool shouldBoost = alive
+                            && controller.GetCanTakeDamage()
+                            && nearDeathOnNormalPool
+                            && !hasLifeblood;
                         if (shouldBoost != furyActive)
                         {
                             furyActive = shouldBoost;


### PR DESCRIPTION
## Summary
- ensure Fury of the Fallen only boosts the shade while it is alive, vulnerable, and out of lifeblood
- add HUD support for assist mode so the shade's health masks hide while damage is disabled
- push the assist state into the HUD alongside health updates

## Testing
- `dotnet test -c Release` *(fails: dotnet not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d45d7bf5388320a19c0186c604b068