### PR TITLE
Improve assist HUD handling and add Fury aura

### DIFF
--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -42,7 +42,9 @@ public partial class SimpleHUD : MonoBehaviour
     private int prevHornetMax;
     private bool hasExplicitShadeStats;
     private bool shadeOvercharmed;
+    private bool shadeAssistModeActive;
     private bool suppressNextDamageSound;
+    private bool pendingMaskRefresh;
 
     // UI containers
     private GameObject healthContainer;
@@ -294,9 +296,32 @@ public partial class SimpleHUD : MonoBehaviour
 
         if (maxChanged)
         {
-            RebuildMasks();
+            if (shadeAssistModeActive || healthContainer == null || maskImages == null)
+            {
+                pendingMaskRefresh = true;
+            }
+            else
+            {
+                RebuildMasks();
+                pendingMaskRefresh = false;
+            }
         }
 
+        HandleAssistVisibilityChange();
+        RefreshHealth();
+    }
+
+    public void SetShadeAssistMode(bool assistActive)
+    {
+        if (shadeAssistModeActive == assistActive)
+        {
+            return;
+        }
+
+        shadeAssistModeActive = assistActive;
+        pendingMaskRefresh |= !assistActive;
+        previousShadeTotalHealth = shadeHealth + shadeLifeblood;
+        HandleAssistVisibilityChange();
         RefreshHealth();
     }
 

--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -296,15 +296,7 @@ public partial class SimpleHUD : MonoBehaviour
 
         if (maxChanged)
         {
-            if (shadeAssistModeActive || healthContainer == null || maskImages == null)
-            {
-                pendingMaskRefresh = true;
-            }
-            else
-            {
-                RebuildMasks();
-                pendingMaskRefresh = false;
-            }
+            pendingMaskRefresh = true;
         }
 
         HandleAssistVisibilityChange();

--- a/LegacyHelper.ShadeController.Charms.cs
+++ b/LegacyHelper.ShadeController.Charms.cs
@@ -235,7 +235,23 @@ public partial class LegacyHelper
             int previousLoadoutMax = Mathf.Max(0, baseShadeMaxHP + charmMaxHpBonus);
             charmMaxHpBonus = Mathf.Clamp(charmMaxHpBonus + amount, -20, 40);
             int newLoadoutMax = Mathf.Max(0, baseShadeMaxHP + charmMaxHpBonus);
-            int fill = fillNew ? Mathf.Max(0, newLoadoutMax - previousLoadoutMax) : 0;
+
+            int fill = 0;
+            if (fillNew)
+            {
+                if (jonisBlessingEquipped)
+                {
+                    int lifebloodCapacity = Mathf.Clamp(charmLifebloodBonus, 0, 99);
+                    int jonisBase = Mathf.Max(1, newLoadoutMax);
+                    lifebloodCapacity += Mathf.CeilToInt(jonisBase * 1.4f);
+                    fill = Mathf.Max(0, lifebloodCapacity - prevLifeblood);
+                }
+                else
+                {
+                    fill = Mathf.Max(0, newLoadoutMax - prevNormalHp);
+                }
+            }
+
             LogCharmHealthEvent($"AddMaxHpBonus amount={amount} fillNew={fillNew} previousLoadoutMax={previousLoadoutMax} newLoadoutMax={newLoadoutMax} prevNormal={prevNormalHp}/{prevNormalMax} prevLifeblood={prevLifeblood}/{prevLifebloodMax} wasJonis={wasJonis}");
             ApplyCharmHealthModifiers(
                 fillAmount: fill,

--- a/LegacyHelper.ShadeController.Charms.cs
+++ b/LegacyHelper.ShadeController.Charms.cs
@@ -14,7 +14,6 @@ public partial class LegacyHelper
                 return;
             }
 
-            ResetCharmHealthBatchTracking();
             EnterPersistenceSuppression();
             try
             {
@@ -97,7 +96,6 @@ public partial class LegacyHelper
 
         internal void ResetCharmDerivedStats()
         {
-            ResetCharmHealthBatchTracking();
             charmNailDamageMultiplier = 1f;
             charmSpellDamageMultiplier = 1f;
             charmNailScaleMultiplier = 1f;
@@ -236,19 +234,15 @@ public partial class LegacyHelper
             charmMaxHpBonus = Mathf.Clamp(charmMaxHpBonus + amount, -20, 40);
             int newLoadoutMax = Mathf.Max(0, baseShadeMaxHP + charmMaxHpBonus);
             int fill = fillNew ? Mathf.Max(0, newLoadoutMax - previousLoadoutMax) : 0;
-            QueueCharmHealthMutation(
+            ApplyCharmHealthModifiers(
                 fillAmount: fill,
                 refillLifeblood: false,
+                deferHudAndPersistence: persistenceSuppressionDepth > 0,
                 previousNormalHpOverride: prevNormalHp,
                 previousNormalMaxOverride: prevNormalMax,
                 previousLifebloodOverride: prevLifeblood,
                 previousLifebloodMaxOverride: prevLifebloodMax,
                 previousJonisOverride: wasJonis);
-
-            if (!applyingCharmLoadout)
-            {
-                FinalizeCharmHealthBatch();
-            }
         }
 
         internal void AddLifebloodBonus(int amount)
@@ -261,19 +255,15 @@ public partial class LegacyHelper
 
             charmLifebloodBonus = Mathf.Clamp(charmLifebloodBonus + amount, 0, 99);
             bool refill = amount > 0 && ShouldRefillLifebloodImmediately();
-            QueueCharmHealthMutation(
+            ApplyCharmHealthModifiers(
                 fillAmount: 0,
                 refillLifeblood: refill,
+                deferHudAndPersistence: persistenceSuppressionDepth > 0,
                 previousNormalHpOverride: prevNormalHp,
                 previousNormalMaxOverride: prevNormalMax,
                 previousLifebloodOverride: prevLifeblood,
                 previousLifebloodMaxOverride: prevLifebloodMax,
                 previousJonisOverride: wasJonis);
-
-            if (!applyingCharmLoadout)
-            {
-                FinalizeCharmHealthBatch();
-            }
         }
 
         internal void SetJonisBlessingActive(bool active)
@@ -296,19 +286,15 @@ public partial class LegacyHelper
             }
 
             bool refill = jonisBlessingEquipped && ShouldRefillLifebloodImmediately();
-            QueueCharmHealthMutation(
+            ApplyCharmHealthModifiers(
                 fillAmount: 0,
                 refillLifeblood: refill,
+                deferHudAndPersistence: persistenceSuppressionDepth > 0,
                 previousNormalHpOverride: prevNormalHp,
                 previousNormalMaxOverride: prevNormalMax,
                 previousLifebloodOverride: prevLifeblood,
                 previousLifebloodMaxOverride: prevLifebloodMax,
                 previousJonisOverride: wasJonis);
-
-            if (!applyingCharmLoadout)
-            {
-                FinalizeCharmHealthBatch();
-            }
         }
 
         internal bool IsJonisBlessingActive() => jonisBlessingEquipped;
@@ -414,79 +400,6 @@ public partial class LegacyHelper
 
             int baseAmount = ModConfig.Instance.focusHornetHeal + charmHornetFocusHealBonus;
             return Mathf.Clamp(baseAmount, 0, 12);
-        }
-
-        private void QueueCharmHealthMutation(
-            int fillAmount,
-            bool refillLifeblood,
-            int? previousNormalHpOverride,
-            int? previousNormalMaxOverride,
-            int? previousLifebloodOverride,
-            int? previousLifebloodMaxOverride,
-            bool? previousJonisOverride)
-        {
-            int prevNormalMax = Mathf.Max(0, previousNormalMaxOverride ?? shadeMaxHP);
-            int prevNormalHp = Mathf.Clamp(previousNormalHpOverride ?? shadeHP, 0, prevNormalMax);
-            int prevLifebloodMax = Mathf.Max(0, previousLifebloodMaxOverride ?? shadeLifebloodMax);
-            int prevLifeblood = Mathf.Clamp(previousLifebloodOverride ?? shadeLifeblood, 0, prevLifebloodMax);
-            bool prevJonis = previousJonisOverride ?? jonisBlessingEquipped;
-
-            if (!charmHealthBatchActive)
-            {
-                charmHealthBatchActive = true;
-                charmHealthBatchPrevNormalHp = prevNormalHp;
-                charmHealthBatchPrevNormalMax = prevNormalMax;
-                charmHealthBatchPrevLifeblood = prevLifeblood;
-                charmHealthBatchPrevLifebloodMax = prevLifebloodMax;
-                charmHealthBatchPrevJonis = prevJonis;
-                charmHealthBatchPositiveFill = Mathf.Max(0, fillAmount);
-                charmHealthBatchRefillLifeblood = refillLifeblood;
-            }
-            else
-            {
-                charmHealthBatchPositiveFill += Mathf.Max(0, fillAmount);
-                charmHealthBatchRefillLifeblood |= refillLifeblood;
-            }
-        }
-
-        private void FinalizeCharmHealthBatch()
-        {
-            if (!charmHealthBatchActive)
-            {
-                return;
-            }
-
-            int fill = charmHealthBatchPositiveFill;
-            bool refill = charmHealthBatchRefillLifeblood;
-            int prevHp = charmHealthBatchPrevNormalHp;
-            int prevMax = charmHealthBatchPrevNormalMax;
-            int prevLifeblood = charmHealthBatchPrevLifeblood;
-            int prevLifebloodMax = charmHealthBatchPrevLifebloodMax;
-            bool prevJonis = charmHealthBatchPrevJonis;
-
-            ResetCharmHealthBatchTracking();
-
-            ApplyCharmHealthModifiers(
-                fillAmount: fill,
-                refillLifeblood: refill,
-                deferHudAndPersistence: persistenceSuppressionDepth > 0,
-                previousNormalHpOverride: prevHp,
-                previousNormalMaxOverride: prevMax,
-                previousLifebloodOverride: prevLifeblood,
-                previousLifebloodMaxOverride: prevLifebloodMax,
-                previousJonisOverride: prevJonis);
-        }
-
-        private void ResetCharmHealthBatchTracking()
-        {
-            charmHealthBatchActive = false;
-            charmHealthBatchPositiveFill = 0;
-            charmHealthBatchRefillLifeblood = false;
-            charmHealthBatchPrevNormalHp = 0;
-            charmHealthBatchPrevNormalMax = 0;
-            charmHealthBatchPrevLifeblood = 0;
-            charmHealthBatchPrevLifebloodMax = 0;
-            charmHealthBatchPrevJonis = jonisBlessingEquipped;
         }
 
         private void ApplyCharmHealthModifiers(

--- a/LegacyHelper.ShadeController.Charms.cs
+++ b/LegacyHelper.ShadeController.Charms.cs
@@ -486,7 +486,12 @@ public partial class LegacyHelper
                 && hivebloodPendingLifebloodRestore
                 && shadeLifeblood < shadeLifebloodMax;
 
-            if (!deferHudAndPersistence)
+            if (deferHudAndPersistence)
+            {
+                pendingDeferredHealthSync = true;
+                pendingDeferredHealthSuppressDamage = true;
+            }
+            else
             {
                 PushShadeStatsToHud(suppressDamageAudio: true);
                 PersistIfChanged();

--- a/LegacyHelper.ShadeController.Charms.cs
+++ b/LegacyHelper.ShadeController.Charms.cs
@@ -475,6 +475,12 @@ public partial class LegacyHelper
                     : Mathf.Clamp(prevLifeblood, 0, targetLifebloodMax);
             }
 
+            bool statsChanged =
+                targetNormalMax != prevNormalMax
+                || targetLifebloodMax != prevLifebloodMax
+                || newNormalHp != prevNormalHp
+                || newLifeblood != prevLifeblood;
+
             shadeMaxHP = targetNormalMax;
             shadeHP = targetNormalMax > 0
                 ? Mathf.Clamp(newNormalHp, 0, targetNormalMax)
@@ -488,10 +494,14 @@ public partial class LegacyHelper
 
             if (deferHudAndPersistence)
             {
-                pendingDeferredHealthSync = true;
-                pendingDeferredHealthSuppressDamage = true;
+                if (statsChanged)
+                {
+                    pendingDeferredHealthSync = true;
+                    pendingDeferredHealthSuppressDamage = true;
+                    PushShadeStatsToHud(suppressDamageAudio: true);
+                }
             }
-            else
+            else if (statsChanged)
             {
                 PushShadeStatsToHud(suppressDamageAudio: true);
                 PersistIfChanged();

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -165,7 +166,7 @@ public partial class LegacyHelper
             equippedCharms.AddRange(charmSnapshot.Definitions);
 
             var currentDefinitions = charmSnapshot.Definitions;
-            HashSet<ShadeCharmDefinition>? currentSet = null;
+            HashSet<ShadeCharmDefinition> currentSet = null;
             ShadeCharmDefinition[] removedCharms = Array.Empty<ShadeCharmDefinition>();
             if (previousEquipped.Length > 0)
             {

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using LegacyoftheAbyss.Shade;
 using UnityEngine;
@@ -141,7 +142,7 @@ public partial class LegacyHelper
         internal void ApplyCharmLoadout(IEnumerable<ShadeCharmDefinition> loadout)
         {
             var previousSnapshot = charmSnapshot;
-            var removedCharms = equippedCharms.ToArray();
+            var previousEquipped = equippedCharms.ToArray();
 
             var sanitized = new List<ShadeCharmDefinition>();
             if (loadout != null)
@@ -162,6 +163,17 @@ public partial class LegacyHelper
 
             equippedCharms.Clear();
             equippedCharms.AddRange(charmSnapshot.Definitions);
+
+            var currentDefinitions = charmSnapshot.Definitions;
+            HashSet<ShadeCharmDefinition>? currentSet = null;
+            ShadeCharmDefinition[] removedCharms = Array.Empty<ShadeCharmDefinition>();
+            if (previousEquipped.Length > 0)
+            {
+                currentSet = currentSet ?? new HashSet<ShadeCharmDefinition>(currentDefinitions);
+                removedCharms = previousEquipped
+                    .Where(charm => charm != null && !currentSet.Contains(charm))
+                    .ToArray();
+            }
 
             charmUpdateCallbacks.Clear();
             charmDamageCallbacks.Clear();

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -230,7 +230,6 @@ public partial class LegacyHelper
             }
             finally
             {
-                FinalizeCharmHealthBatch();
                 applyingCharmLoadout = previousApplyingLoadout;
             }
 

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -204,24 +204,34 @@ public partial class LegacyHelper
                 PushSoulToHud();
             }
 
-            if (removedCharms.Length > 0)
+            bool previousApplyingLoadout = applyingCharmLoadout;
+            applyingCharmLoadout = true;
+            try
             {
-                var removedContext = new ShadeCharmContext(this, previousSnapshot);
-                foreach (var removed in removedCharms)
+                if (removedCharms.Length > 0)
                 {
-                    try { removed.Hooks.OnRemoved?.Invoke(removedContext); }
-                    catch { }
+                    var removedContext = new ShadeCharmContext(this, previousSnapshot);
+                    foreach (var removed in removedCharms)
+                    {
+                        try { removed.Hooks.OnRemoved?.Invoke(removedContext); }
+                        catch { }
+                    }
+                }
+
+                if (equippedCharms.Count > 0)
+                {
+                    var appliedContext = new ShadeCharmContext(this, charmSnapshot);
+                    foreach (var applied in equippedCharms)
+                    {
+                        try { applied.Hooks.OnApplied?.Invoke(appliedContext); }
+                        catch { }
+                    }
                 }
             }
-
-            if (equippedCharms.Count > 0)
+            finally
             {
-                var appliedContext = new ShadeCharmContext(this, charmSnapshot);
-                foreach (var applied in equippedCharms)
-                {
-                    try { applied.Hooks.OnApplied?.Invoke(appliedContext); }
-                    catch { }
-                }
+                FinalizeCharmHealthBatch();
+                applyingCharmLoadout = previousApplyingLoadout;
             }
 
             if (pendingRestoredLifebloodMax >= 0)

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -1264,28 +1264,29 @@ public partial class LegacyHelper
                 var main = furyAuraPs.main;
                 main.loop = true;
                 main.playOnAwake = false;
-                main.startLifetime = new ParticleSystem.MinMaxCurve(0.45f, 0.7f);
-                main.startSpeed = new ParticleSystem.MinMaxCurve(0.1f, 0.4f);
-                main.startSize = new ParticleSystem.MinMaxCurve(0.18f, 0.32f);
-                main.startColor = new Color(0.55f, 0.05f, 0.08f, 0.85f);
+                main.startLifetime = new ParticleSystem.MinMaxCurve(0.55f, 0.95f);
+                main.startSpeed = new ParticleSystem.MinMaxCurve(0.45f, 1.35f);
+                main.startSize = new ParticleSystem.MinMaxCurve(0.22f, 0.38f);
+                main.startColor = new Color(0.95f, 0.12f, 0.16f, 0.95f);
                 main.simulationSpace = ParticleSystemSimulationSpace.Local;
-                main.maxParticles = 64;
+                main.maxParticles = 120;
 
                 var emission = furyAuraPs.emission;
                 emission.enabled = true;
-                emission.rateOverTime = new ParticleSystem.MinMaxCurve(12f, 16f);
+                emission.rateOverTime = new ParticleSystem.MinMaxCurve(28f, 36f);
 
                 var shape = furyAuraPs.shape;
                 shape.enabled = true;
                 shape.shapeType = ParticleSystemShapeType.Circle;
-                shape.radius = 0.45f;
+                shape.radius = 0.15f;
+                shape.radiusThickness = 0f;
                 shape.arcMode = ParticleSystemShapeMultiModeValue.Random;
                 shape.arcSpread = 1f;
 
                 var velocity = furyAuraPs.velocityOverLifetime;
                 velocity.enabled = true;
-                velocity.radial = 0.35f;
-                velocity.orbitalZ = 0.15f;
+                velocity.radial = new ParticleSystem.MinMaxCurve(1.1f, 1.8f);
+                velocity.orbitalZ = new ParticleSystem.MinMaxCurve(-0.35f, 0.35f);
 
                 var color = furyAuraPs.colorOverLifetime;
                 color.enabled = true;
@@ -1293,12 +1294,12 @@ public partial class LegacyHelper
                 grad.SetKeys(
                     new[]
                     {
-                        new GradientColorKey(new Color(0.7f, 0.12f, 0.16f, 1f), 0f),
-                        new GradientColorKey(new Color(0.35f, 0f, 0f, 1f), 1f)
+                        new GradientColorKey(new Color(1f, 0.2f, 0.22f, 1f), 0f),
+                        new GradientColorKey(new Color(0.36f, 0f, 0f, 1f), 1f)
                     },
                     new[]
                     {
-                        new GradientAlphaKey(0.85f, 0f),
+                        new GradientAlphaKey(0.95f, 0f),
                         new GradientAlphaKey(0f, 1f)
                     });
                 color.color = grad;
@@ -1306,8 +1307,9 @@ public partial class LegacyHelper
                 var size = furyAuraPs.sizeOverLifetime;
                 size.enabled = true;
                 size.size = new ParticleSystem.MinMaxCurve(1f, new AnimationCurve(
-                    new Keyframe(0f, 0.85f),
-                    new Keyframe(1f, 1.1f)));
+                    new Keyframe(0f, 0.75f),
+                    new Keyframe(0.5f, 1.05f),
+                    new Keyframe(1f, 1.25f)));
 
                 var renderer = furyAuraPs.GetComponent<ParticleSystemRenderer>();
                 if (renderer)
@@ -1315,7 +1317,15 @@ public partial class LegacyHelper
                     renderer.renderMode = ParticleSystemRenderMode.Billboard;
                     if (s_furyAuraMat == null)
                     {
-                        s_furyAuraMat = new Material(Shader.Find("Sprites/Default"));
+                        var shader = Shader.Find("Particles/Additive");
+                        if (!shader)
+                        {
+                            shader = Shader.Find("Sprites/Default");
+                        }
+
+                        s_furyAuraMat = shader != null
+                            ? new Material(shader)
+                            : new Material(Shader.Find("Sprites/Default"));
                         s_furyAuraMat.color = Color.white;
                     }
                     renderer.sharedMaterial = s_furyAuraMat;

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -66,7 +66,7 @@ public partial class LegacyHelper
             try { gameObject.tag = "Recoiler"; } catch { }
 
             SetupShadeLight();
-            cachedHud = Object.FindFirstObjectByType<SimpleHUD>();
+            cachedHud = UnityEngine.Object.FindFirstObjectByType<SimpleHUD>();
             PushSoulToHud();
             CheckHazardOverlap();
             // Ensure pogo target is present for Hornet downslash bounces
@@ -585,7 +585,7 @@ public partial class LegacyHelper
             bool pushedSoulThisFrame = false;
             if (!cachedHud)
             {
-                var resolvedHud = Object.FindFirstObjectByType<SimpleHUD>();
+                var resolvedHud = UnityEngine.Object.FindFirstObjectByType<SimpleHUD>();
                 if (resolvedHud)
                 {
                     cachedHud = resolvedHud;
@@ -1195,7 +1195,7 @@ public partial class LegacyHelper
                 battleCheckTimer -= Time.deltaTime;
                 if (battleCheckTimer <= 0f || cachedBattle == null)
                 {
-                    cachedBattle = Object.FindFirstObjectByType<BattleScene>();
+                    cachedBattle = UnityEngine.Object.FindFirstObjectByType<BattleScene>();
                     battleCheckTimer = 1f;
                 }
                 if (cachedBattle != null)
@@ -2095,7 +2095,7 @@ public partial class LegacyHelper
                 HealthManager[] enemies = null;
                 try
                 {
-                    enemies = Object.FindObjectsByType<HealthManager>(
+                    enemies = UnityEngine.Object.FindObjectsByType<HealthManager>(
                         FindObjectsInactive.Exclude,
                         FindObjectsSortMode.None);
                 }

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -123,7 +123,15 @@ public partial class LegacyHelper
                     sceneProtectionSuppressingPersistence = false;
                 }
 
-                LegacyHelper.SaveShadeState(shadeHP, shadeMaxHP, shadeLifeblood, shadeLifebloodMax, shadeSoul, canTakeDamage, baseShadeMaxHP);
+                bool desiredDamageState = sceneProtectionActive ? sceneProtectionDesiredDamageState : canTakeDamage;
+                LegacyHelper.SaveShadeState(
+                    shadeHP,
+                    shadeMaxHP,
+                    shadeLifeblood,
+                    shadeLifebloodMax,
+                    shadeSoul,
+                    desiredDamageState,
+                    baseShadeMaxHP);
             }
             catch
             {

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -265,7 +265,25 @@ public partial class LegacyHelper
             if (persistenceSuppressionDepth > 0)
             {
                 persistenceSuppressionDepth--;
+                if (persistenceSuppressionDepth == 0)
+                {
+                    FlushDeferredHealthSync();
+                }
             }
+        }
+
+        private void FlushDeferredHealthSync()
+        {
+            if (!pendingDeferredHealthSync)
+            {
+                return;
+            }
+
+            bool suppressDamage = pendingDeferredHealthSuppressDamage;
+            pendingDeferredHealthSync = false;
+            pendingDeferredHealthSuppressDamage = false;
+            PushShadeStatsToHud(suppressDamageAudio: suppressDamage);
+            PersistIfChanged();
         }
 
         private void LoadShadeSprites()

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -256,5 +256,7 @@ public partial class LegacyHelper
         private int lastSavedSoul;
         private bool lastSavedCanTakeDamage = true;
         private int persistenceSuppressionDepth;
+        private bool pendingDeferredHealthSync;
+        private bool pendingDeferredHealthSuppressDamage;
     }
 }

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -140,6 +140,7 @@ public partial class LegacyHelper
         private const float SnapMinWhenNoRoom = 0.25f;
 
         private bool canTakeDamage = true;
+        private bool assistModeEnabled;
         private float sceneProtectionTimer;
         private bool sceneProtectionActive;
         private bool sceneProtectionDesiredDamageState = true;
@@ -165,6 +166,10 @@ public partial class LegacyHelper
         private float sprintDashCooldown = s_defaultCharmStats.SprintDashCooldown;
         private ParticleSystem activeDashPs;
         private Vector2 activeDashDir;
+
+        private GameObject furyAuraObject;
+        private ParticleSystem furyAuraPs;
+        private static Material s_furyAuraMat;
 
         // Inactive state (at 0 HP)
         private bool isInactive;

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -235,6 +235,12 @@ public partial class LegacyHelper
         private float conditionalNailDamageProduct = 1f;
 
         private SimpleHUD cachedHud;
+        private bool pendingHudStatsSync;
+        private bool pendingHudAssistSync;
+        private bool pendingHudOvercharmSync;
+        private bool pendingHudSoulSync;
+        private bool pendingHudSuppressDamageSfx;
+        private Coroutine hudSyncRoutine;
         private float hurtCooldown;
         private const float HurtIFrameSeconds = 1.35f;
         private const float ReviveIFrameSeconds = 1.5f;

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -144,6 +144,7 @@ public partial class LegacyHelper
         private float sceneProtectionTimer;
         private bool sceneProtectionActive;
         private bool sceneProtectionDesiredDamageState = true;
+        private bool sceneProtectionSuppressingPersistence;
         private readonly Collider2D[] sceneProtectionOverlapBuffer = new Collider2D[16];
         private Vector2 capturedMoveInput;
         private float capturedHorizontalInput;

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -258,5 +258,14 @@ public partial class LegacyHelper
         private int persistenceSuppressionDepth;
         private bool pendingDeferredHealthSync;
         private bool pendingDeferredHealthSuppressDamage;
+        private bool applyingCharmLoadout;
+        private bool charmHealthBatchActive;
+        private int charmHealthBatchPrevNormalHp;
+        private int charmHealthBatchPrevNormalMax;
+        private int charmHealthBatchPrevLifeblood;
+        private int charmHealthBatchPrevLifebloodMax;
+        private bool charmHealthBatchPrevJonis;
+        private int charmHealthBatchPositiveFill;
+        private bool charmHealthBatchRefillLifeblood;
     }
 }

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -259,13 +259,5 @@ public partial class LegacyHelper
         private bool pendingDeferredHealthSync;
         private bool pendingDeferredHealthSuppressDamage;
         private bool applyingCharmLoadout;
-        private bool charmHealthBatchActive;
-        private int charmHealthBatchPrevNormalHp;
-        private int charmHealthBatchPrevNormalMax;
-        private int charmHealthBatchPrevLifeblood;
-        private int charmHealthBatchPrevLifebloodMax;
-        private bool charmHealthBatchPrevJonis;
-        private int charmHealthBatchPositiveFill;
-        private bool charmHealthBatchRefillLifeblood;
     }
 }

--- a/LegacyHelper.ShadeController.Persistence.cs
+++ b/LegacyHelper.ShadeController.Persistence.cs
@@ -17,6 +17,7 @@ public partial class LegacyHelper
             shadeLifeblood = pendingRestoredLifeblood;
             shadeSoul = Mathf.Clamp(soul, 0, shadeSoulMax);
             canTakeDamage = canDamage;
+            assistModeEnabled = !canTakeDamage;
             lastSavedCanTakeDamage = canTakeDamage;
 
             if (baseShadeMaxHP <= 0)
@@ -148,6 +149,7 @@ public partial class LegacyHelper
                 }
 
                 hud.SetShadeStats(shadeHP, shadeMaxHP, shadeLifeblood, shadeLifebloodMax);
+                hud.SetShadeAssistMode(assistModeEnabled);
                 hud.SetShadeOvercharmed(ShadeRuntime.Charms?.IsOvercharmed ?? false);
             }
             catch

--- a/LegacyHelper.ShadeController.Persistence.cs
+++ b/LegacyHelper.ShadeController.Persistence.cs
@@ -19,6 +19,10 @@ public partial class LegacyHelper
             shadeSoul = Mathf.Clamp(soul, 0, shadeSoulMax);
             canTakeDamage = canDamage;
             assistModeEnabled = !canTakeDamage;
+            sceneProtectionDesiredDamageState = canTakeDamage;
+            sceneProtectionActive = false;
+            sceneProtectionTimer = 0f;
+            sceneProtectionSuppressingPersistence = false;
             lastSavedCanTakeDamage = canTakeDamage;
 
             if (baseShadeMaxHP <= 0)

--- a/LegacyHelper.ShadeController.Persistence.cs
+++ b/LegacyHelper.ShadeController.Persistence.cs
@@ -76,7 +76,10 @@ public partial class LegacyHelper
         public int GetMaxLifeblood() => Mathf.Max(0, shadeLifebloodMax);
         public int GetShadeSoul() => shadeSoul;
         public int GetShadeSoulMax() => shadeSoulMax;
-        public bool GetCanTakeDamage() => canTakeDamage;
+        public bool GetCanTakeDamage()
+        {
+            return sceneProtectionActive ? sceneProtectionDesiredDamageState : canTakeDamage;
+        }
 
         public void Init(Transform hornet) { hornetTransform = hornet; }
 

--- a/Shade/ShadeCharmInventory.cs
+++ b/Shade/ShadeCharmInventory.cs
@@ -282,11 +282,13 @@ namespace LegacyoftheAbyss.Shade
                     {
                         furyActive = false;
                         ctx.Controller?.SetConditionalNailDamageMultiplier(nameof(ShadeCharmId.FuryOfTheFallen), 1f);
+                        ctx.Controller?.SetFuryModeActive(false);
                     },
                     OnRemoved = ctx =>
                     {
                         furyActive = false;
                         ctx.Controller?.ClearConditionalNailDamageMultiplier(nameof(ShadeCharmId.FuryOfTheFallen));
+                        ctx.Controller?.SetFuryModeActive(false);
                     },
                     OnUpdate = (ctx, _) =>
                     {
@@ -301,6 +303,7 @@ namespace LegacyoftheAbyss.Shade
                         {
                             furyActive = shouldBoost;
                             controller.SetConditionalNailDamageMultiplier(nameof(ShadeCharmId.FuryOfTheFallen), shouldBoost ? 1.75f : 1f);
+                            controller.SetFuryModeActive(shouldBoost);
                         }
                     }
                 },

--- a/Shade/ShadeCharmInventory.cs
+++ b/Shade/ShadeCharmInventory.cs
@@ -1038,10 +1038,13 @@ namespace LegacyoftheAbyss.Shade
             {
                 foreach (var id in SanitizeIds(equipped))
                 {
-                    if (_owned.Contains(id) && !_broken.Contains(id))
+                    if (_broken.Contains(id))
                     {
-                        AddEquippedInternal(id);
+                        continue;
                     }
+
+                    _owned.Add(id);
+                    AddEquippedInternal(id);
                 }
             }
 

--- a/Shade/ShadePersistentState.cs
+++ b/Shade/ShadePersistentState.cs
@@ -326,7 +326,7 @@ namespace LegacyoftheAbyss.Shade
 
         public void SetDiscoveredCharms(IEnumerable<int>? charmIds)
         {
-            _discoveredCharmIds.Clear();
+            var sanitized = new HashSet<int>();
 
             if (charmIds != null)
             {
@@ -334,12 +334,37 @@ namespace LegacyoftheAbyss.Shade
                 {
                     if (charmId >= 0)
                     {
-                        _discoveredCharmIds.Add(charmId);
+                        sanitized.Add(charmId);
                     }
                 }
             }
 
-            if (_equippedCharmLoadouts.Count == 0)
+            if (_equippedCharmLoadouts.Count > 0)
+            {
+                foreach (var loadout in _equippedCharmLoadouts.Values)
+                {
+                    if (loadout == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var charmId in loadout)
+                    {
+                        if (charmId >= 0)
+                        {
+                            sanitized.Add(charmId);
+                        }
+                    }
+                }
+            }
+
+            if (!_discoveredCharmIds.SetEquals(sanitized))
+            {
+                _discoveredCharmIds.Clear();
+                _discoveredCharmIds.UnionWith(sanitized);
+            }
+
+            if (_equippedCharmLoadouts.Count == 0 || sanitized.Count == 0)
             {
                 return;
             }
@@ -352,7 +377,7 @@ namespace LegacyoftheAbyss.Shade
                     continue;
                 }
 
-                loadout.RemoveWhere(id => !_discoveredCharmIds.Contains(id));
+                loadout.RemoveWhere(id => !sanitized.Contains(id));
                 if (loadout.Count == 0)
                 {
                     _equippedCharmLoadouts.Remove(loadoutId);

--- a/Shade/ShadePersistentState.cs
+++ b/Shade/ShadePersistentState.cs
@@ -324,6 +324,42 @@ namespace LegacyoftheAbyss.Shade
             return removed;
         }
 
+        public void SetDiscoveredCharms(IEnumerable<int>? charmIds)
+        {
+            _discoveredCharmIds.Clear();
+
+            if (charmIds != null)
+            {
+                foreach (var charmId in charmIds)
+                {
+                    if (charmId >= 0)
+                    {
+                        _discoveredCharmIds.Add(charmId);
+                    }
+                }
+            }
+
+            if (_equippedCharmLoadouts.Count == 0)
+            {
+                return;
+            }
+
+            var loadoutIds = _equippedCharmLoadouts.Keys.ToArray();
+            foreach (var loadoutId in loadoutIds)
+            {
+                if (!_equippedCharmLoadouts.TryGetValue(loadoutId, out var loadout) || loadout == null)
+                {
+                    continue;
+                }
+
+                loadout.RemoveWhere(id => !_discoveredCharmIds.Contains(id));
+                if (loadout.Count == 0)
+                {
+                    _equippedCharmLoadouts.Remove(loadoutId);
+                }
+            }
+        }
+
         public IReadOnlyCollection<int> GetDiscoveredCharmIdsSnapshot()
         {
             if (_discoveredCharmIds.Count == 0)

--- a/Shade/ShadeRuntime.cs
+++ b/Shade/ShadeRuntime.cs
@@ -535,6 +535,10 @@ namespace LegacyoftheAbyss.Shade
         {
             EnsureActiveSlot();
 
+            s_saveSlots.GetOrCreateSlot(s_activeSlot);
+            bool debugPersisted = s_saveSlots.IsDebugUnlockActive(s_activeSlot);
+            DisableDebugUnlockIfActive(persist: !debugPersisted);
+
             var owned = s_saveSlots.GetCollectedCharms(s_activeSlot);
             var broken = s_saveSlots.GetBrokenCharms(s_activeSlot);
             var equipped = ConvertToCharmIds(s_saveSlots.GetEquippedCharms(s_activeSlot, 0));
@@ -610,7 +614,7 @@ namespace LegacyoftheAbyss.Shade
                 s_charmInventory.NotchCapacity);
         }
 
-        private static void DisableDebugUnlockIfActive()
+        private static void DisableDebugUnlockIfActive(bool persist = true)
         {
             if (!s_debugUnlockAllCharmsActive)
             {
@@ -622,15 +626,18 @@ namespace LegacyoftheAbyss.Shade
             s_debugUnlockAllCharmsActive = false;
             s_debugCharmSnapshot = null;
 
-            ShadeDebugCharmSnapshot? persistenceSnapshot = snapshot.HasValue
-                ? new ShadeDebugCharmSnapshot(
-                    snapshot.Value.Owned,
-                    snapshot.Value.Equipped,
-                    snapshot.Value.Broken,
-                    snapshot.Value.NewlyDiscovered,
-                    snapshot.Value.NotchCapacity)
-                : (ShadeDebugCharmSnapshot?)null;
-            s_saveSlots.SetDebugUnlockState(s_activeSlot, false, persistenceSnapshot);
+            if (persist)
+            {
+                ShadeDebugCharmSnapshot? persistenceSnapshot = snapshot.HasValue
+                    ? new ShadeDebugCharmSnapshot(
+                        snapshot.Value.Owned,
+                        snapshot.Value.Equipped,
+                        snapshot.Value.Broken,
+                        snapshot.Value.NewlyDiscovered,
+                        snapshot.Value.NotchCapacity)
+                    : (ShadeDebugCharmSnapshot?)null;
+                s_saveSlots.SetDebugUnlockState(s_activeSlot, false, persistenceSnapshot);
+            }
 
             if (snapshot.HasValue)
             {

--- a/Shade/ShadeRuntime.cs
+++ b/Shade/ShadeRuntime.cs
@@ -303,14 +303,23 @@ namespace LegacyoftheAbyss.Shade
 
         internal static void SetActiveSlot(int slot)
         {
-            DisableDebugUnlockIfActive();
-
             int clamped = s_saveSlots.MaxSlots > 0
                 ? Mathf.Clamp(slot, 0, s_saveSlots.MaxSlots - 1)
                 : 0;
 
-            s_activeSlot = clamped;
-            s_hasActiveSlot = true;
+            bool switching = !s_hasActiveSlot || s_activeSlot != clamped;
+            if (switching)
+            {
+                DisableDebugUnlockIfActive();
+                s_activeSlot = clamped;
+                s_hasActiveSlot = true;
+            }
+            else if (!s_hasActiveSlot)
+            {
+                s_activeSlot = clamped;
+                s_hasActiveSlot = true;
+            }
+
             s_saveSlots.GetOrCreateSlot(s_activeSlot);
             SyncInventoryFromActiveSlot();
             LegacyHelper.RequestShadeLoadoutRecompute();
@@ -524,7 +533,6 @@ namespace LegacyoftheAbyss.Shade
 
         private static void SyncInventoryFromActiveSlot()
         {
-            DisableDebugUnlockIfActive();
             EnsureActiveSlot();
 
             var owned = s_saveSlots.GetCollectedCharms(s_activeSlot);

--- a/Shade/ShadeSaveSlotRepository.cs
+++ b/Shade/ShadeSaveSlotRepository.cs
@@ -442,9 +442,26 @@ namespace LegacyoftheAbyss.Shade
                 }
             }
 
-            var discoveredIds = record.CollectedCharms
-                .Select(charm => (int)charm)
-                .ToArray();
+            var discoveredIds = new HashSet<int>(record.CollectedCharms
+                .Select(charm => (int)charm));
+
+            var loadouts = record.State.GetEquippedCharmLoadouts();
+            foreach (var loadout in loadouts.Values)
+            {
+                if (loadout == null)
+                {
+                    continue;
+                }
+
+                foreach (var charmId in loadout)
+                {
+                    if (charmId >= 0)
+                    {
+                        discoveredIds.Add(charmId);
+                    }
+                }
+            }
+
             record.State.SetDiscoveredCharms(discoveredIds);
 
             PersistSlot(slot);

--- a/Shade/ShadeSaveSlotRepository.cs
+++ b/Shade/ShadeSaveSlotRepository.cs
@@ -442,6 +442,11 @@ namespace LegacyoftheAbyss.Shade
                 }
             }
 
+            var discoveredIds = record.CollectedCharms
+                .Select(charm => (int)charm)
+                .ToArray();
+            record.State.SetDiscoveredCharms(discoveredIds);
+
             PersistSlot(slot);
         }
 
@@ -501,6 +506,12 @@ namespace LegacyoftheAbyss.Shade
             {
                 foreach (var charmId in charmIds)
                 {
+                    if (charmId < 0)
+                    {
+                        continue;
+                    }
+
+                    record.State.UnlockCharm(charmId);
                     record.State.EquipCharm(loadoutId, charmId);
                 }
             }

--- a/ShadeInventoryPane.cs
+++ b/ShadeInventoryPane.cs
@@ -3729,10 +3729,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
         float glowScale = HighlightScaleMultiplier;
         var newSize = new Vector2(baseSize.x * glowScale, baseSize.y * glowScale);
         highlightRect.sizeDelta = newSize;
-
-        string entryName = entryRoot.gameObject != null ? entryRoot.gameObject.name : "<null>";
-        LogMenuEvent(FormattableString.Invariant(
-            $"PositionHighlight -> entry='{entryName}' baseSize={FormatVector2(baseSize)} scale={glowScale:0.##} finalSize={FormatVector2(newSize)}"));
     }
 
     public void ForceLayoutRebuild()
@@ -5888,9 +5884,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
     private void MoveSelectionHorizontal(int direction)
     {
         EnsureBuilt();
-        int originIndex = selectedIndex;
-        LogMenuEvent(FormattableString.Invariant(
-            $"MoveSelectionHorizontal -> direction={direction} selected={selectedIndex} entries={entries.Count} positions={entryGridPositions.Count}"));
         if (entries.Count == 0 || direction == 0)
         {
             UpdateEquippedRow();
@@ -5927,23 +5920,13 @@ internal sealed class ShadeInventoryPane : InventoryPane
 
         if (candidate >= 0)
         {
-            LogMenuEvent(FormattableString.Invariant(
-                $"MoveSelectionHorizontal success -> {originIndex}->{candidate} row={row} targetColumn={targetColumn}"));
             SelectIndex(candidate);
-        }
-        else
-        {
-            LogMenuEvent(FormattableString.Invariant(
-                $"MoveSelectionHorizontal no candidate -> row={row} targetColumn={targetColumn}"));
         }
     }
 
     private void MoveSelectionVertical(int direction)
     {
         EnsureBuilt();
-        int originIndex = selectedIndex;
-        LogMenuEvent(FormattableString.Invariant(
-            $"MoveSelectionVertical -> direction={direction} selected={selectedIndex} entries={entries.Count} positions={entryGridPositions.Count}"));
         if (entries.Count == 0 || direction == 0)
         {
             return;
@@ -5993,14 +5976,7 @@ internal sealed class ShadeInventoryPane : InventoryPane
 
         if (candidate >= 0)
         {
-            LogMenuEvent(FormattableString.Invariant(
-                $"MoveSelectionVertical success -> {originIndex}->{candidate} targetRow={targetRow} distance={candidateDistance:0.###}"));
             SelectIndex(candidate);
-        }
-        else
-        {
-            LogMenuEvent(FormattableString.Invariant(
-                $"MoveSelectionVertical no candidate -> targetRow={targetRow}"));
         }
     }
 
@@ -6053,8 +6029,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
         string entryName = entry.Root != null && entry.Root.gameObject != null
             ? entry.Root.gameObject.name
             : "<null>";
-        LogMenuEvent(FormattableString.Invariant(
-            $"SelectIndex -> {previousIndex}->{selectedIndex} entry='{entryName}' id={entry.Id}"));
         var highlightRect = EnsureHighlightRect();
         RectTransform? entryRoot = entry.Root;
         if (highlightRect != null && entryRoot != null)

--- a/ShadeInventoryPane.cs
+++ b/ShadeInventoryPane.cs
@@ -6009,8 +6009,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
         EnsureBuilt();
         bool skipDuplicate = fromInputComponent && inputHandlersRegistered && lastPaneInputCameFromEvent &&
             lastPaneInputFrame == Time.frameCount && lastPaneInputDirection == direction;
-        LogMenuEvent(FormattableString.Invariant(
-            $"HandleDirectionalInput -> direction={direction} fromInputComponent={fromInputComponent} skipDuplicate={skipDuplicate} selectedIndex={selectedIndex} entryCount={entries.Count}"));
         if (skipDuplicate)
         {
             lastPaneInputCameFromEvent = false;
@@ -6431,8 +6429,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
         var pressed = TryGetShadeDirectionalPress(out var source);
         if (pressed.HasValue)
         {
-            LogMenuEvent(FormattableString.Invariant(
-                $"ProcessShadeDirectionalInput press detected: direction={pressed.Value} source={source}"));
             shadeHeldDirection = pressed;
             shadeHeldDirectionSource = source;
             shadeDirectionRepeatTimer = ShadeInputInitialRepeatDelay;
@@ -6448,8 +6444,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
         var direction = shadeHeldDirection.Value;
         if (!IsShadeDirectionHeld(direction))
         {
-            LogMenuEvent(FormattableString.Invariant(
-                $"ProcessShadeDirectionalInput releasing direction={direction} heldSource={shadeHeldDirectionSource}"));
             ResetShadeInputState("DirectionReleased");
             return;
         }
@@ -6461,8 +6455,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
         }
 
         shadeDirectionRepeatTimer = ShadeInputRepeatInterval;
-        LogMenuEvent(FormattableString.Invariant(
-            $"ProcessShadeDirectionalInput repeat fired: direction={direction} source={shadeHeldDirectionSource} nextRepeat={ShadeInputRepeatInterval:0.###}"));
         HandleDirectionalInput(direction, fromInputComponent: false);
     }
 
@@ -6470,28 +6462,24 @@ internal sealed class ShadeInventoryPane : InventoryPane
     {
         if (ShadeInput.WasActionPressed(ShadeAction.MoveLeft))
         {
-            LogMenuEvent("TryGetShadeDirectionalPress -> Shade MoveLeft pressed");
             source = DirectionalInputSource.ShadeBindings;
             return InventoryPaneBase.InputEventType.Left;
         }
 
         if (ShadeInput.WasActionPressed(ShadeAction.MoveRight))
         {
-            LogMenuEvent("TryGetShadeDirectionalPress -> Shade MoveRight pressed");
             source = DirectionalInputSource.ShadeBindings;
             return InventoryPaneBase.InputEventType.Right;
         }
 
         if (ShadeInput.WasActionPressed(ShadeAction.MoveUp))
         {
-            LogMenuEvent("TryGetShadeDirectionalPress -> Shade MoveUp pressed");
             source = DirectionalInputSource.ShadeBindings;
             return InventoryPaneBase.InputEventType.Up;
         }
 
         if (ShadeInput.WasActionPressed(ShadeAction.MoveDown))
         {
-            LogMenuEvent("TryGetShadeDirectionalPress -> Shade MoveDown pressed");
             source = DirectionalInputSource.ShadeBindings;
             return InventoryPaneBase.InputEventType.Down;
         }
@@ -6541,25 +6529,21 @@ internal sealed class ShadeInventoryPane : InventoryPane
 
         if (actions.Left != null && actions.Left.WasPressed)
         {
-            LogMenuEvent("TryGetHeroDirectionalPress -> Hero Left pressed");
             return InventoryPaneBase.InputEventType.Left;
         }
 
         if (actions.Right != null && actions.Right.WasPressed)
         {
-            LogMenuEvent("TryGetHeroDirectionalPress -> Hero Right pressed");
             return InventoryPaneBase.InputEventType.Right;
         }
 
         if (actions.Up != null && actions.Up.WasPressed)
         {
-            LogMenuEvent("TryGetHeroDirectionalPress -> Hero Up pressed");
             return InventoryPaneBase.InputEventType.Up;
         }
 
         if (actions.Down != null && actions.Down.WasPressed)
         {
-            LogMenuEvent("TryGetHeroDirectionalPress -> Hero Down pressed");
             return InventoryPaneBase.InputEventType.Down;
         }
 
@@ -6707,7 +6691,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
     {
         if (ShadeInput.WasActionPressed(ShadeAction.Nail))
         {
-            LogMenuEvent("ProcessShadeSubmitInput -> Shade slash pressed");
             HandleSubmit();
             return;
         }
@@ -6715,10 +6698,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
         var actions = ResolveHeroActions();
         if (actions == null)
         {
-            if (!loggedMissingHeroActions)
-            {
-                LogMenuEvent("ProcessShadeSubmitInput -> Hero actions unavailable");
-            }
             return;
         }
 
@@ -6726,8 +6705,6 @@ internal sealed class ShadeInventoryPane : InventoryPane
         bool jumpPressed = actions.Jump != null && actions.Jump.WasPressed;
         if (attackPressed || jumpPressed)
         {
-            LogMenuEvent(FormattableString.Invariant(
-                $"ProcessShadeSubmitInput -> Hero submit pressed (attack={attackPressed} jump={jumpPressed})"));
             HandleSubmit();
         }
     }


### PR DESCRIPTION
## Summary
- track assist mode separately from spawn protection and update the HUD so shade masks disappear when assist mode is active
- add a Fury of the Fallen aura so the shade emits dark red particles whenever it fights at 1 HP
- rebuild the shade HUD masks immediately after health changes to avoid waiting for scene transitions

## Testing
- `dotnet test -c Release` *(fails: `dotnet` is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4655c84448320a644bb7a9772ab89