### PR TITLE
Implement Baldur Shell animation, Heavy Blow knockback, and Sharp Shadow

### DIFF
--- a/LegacyHelper.Projectile.cs
+++ b/LegacyHelper.Projectile.cs
@@ -92,17 +92,36 @@ public partial class LegacyHelper
         public int damage = 20;
         public Transform hornetRoot;
         public float lifeSeconds = 0.25f;
+        public GameObject sourceOverride;
+        public AttackTypes attackType = AttackTypes.Spell;
+        public float direction = 90f;
+        public float magnitudeMultiplier = 1f;
+        public float multiplier = 1f;
+        public bool isHeroDamage = true;
+        public bool isFirstHit = true;
         private HashSet<Collider2D> hitSet;
 
         void Awake()
         {
             hitSet = new HashSet<Collider2D>();
-            damage = Mathf.RoundToInt(damage * ModConfig.Instance.shadeDamageMultiplier);
+        }
+
+        public void ConfigureDamage(int amount, bool applyDamageMultiplier)
+        {
+            if (applyDamageMultiplier)
+            {
+                damage = Mathf.Max(0, Mathf.RoundToInt(amount * ModConfig.Instance.shadeDamageMultiplier));
+            }
+            else
+            {
+                damage = Mathf.Max(0, amount);
+            }
         }
 
         void Start()
         {
-            Destroy(gameObject, lifeSeconds);
+            if (lifeSeconds > 0f)
+                Destroy(gameObject, lifeSeconds);
         }
 
         void OnTriggerEnter2D(Collider2D other)
@@ -115,14 +134,14 @@ public partial class LegacyHelper
 
             var hit = new HitInstance
             {
-                Source = gameObject,
-                AttackType = AttackTypes.Spell,
+                Source = sourceOverride ? sourceOverride : gameObject,
+                AttackType = attackType,
                 DamageDealt = damage,
-                Direction = 90f,
-                MagnitudeMultiplier = 1f,
-                Multiplier = 1f,
-                IsHeroDamage = true,
-                IsFirstHit = true
+                Direction = direction,
+                MagnitudeMultiplier = magnitudeMultiplier,
+                Multiplier = multiplier,
+                IsHeroDamage = isHeroDamage,
+                IsFirstHit = isFirstHit
             };
 
             HitTaker.Hit(other.gameObject, hit);

--- a/LegacyHelper.ShadeController.Charms.cs
+++ b/LegacyHelper.ShadeController.Charms.cs
@@ -129,7 +129,7 @@ public partial class LegacyHelper
             voidHeartEvadeActive = false;
             sharpShadowEquipped = false;
             sharpShadowDashActive = false;
-            sharpShadowDashHits.Clear();
+            DestroySharpShadowDashHitbox();
             conditionalNailDamageMultipliers.Clear();
             conditionalNailDamageProduct = 1f;
             UpdateFocusDerivedValues();
@@ -166,6 +166,11 @@ public partial class LegacyHelper
         internal void SetVoidHeartEvadeActive(bool active)
         {
             voidHeartEvadeActive = active;
+            if (!active)
+            {
+                sharpShadowDashActive = false;
+                DestroySharpShadowDashHitbox();
+            }
         }
 
         internal void MultiplyFocusTime(float factor)
@@ -237,8 +242,8 @@ public partial class LegacyHelper
             if (!enabled)
             {
                 sharpShadowDashActive = false;
+                DestroySharpShadowDashHitbox();
             }
-            sharpShadowDashHits.Clear();
         }
 
         internal void SetFocusHealingDisabled(bool disabled)

--- a/LegacyHelper.ShadeController.Charms.cs
+++ b/LegacyHelper.ShadeController.Charms.cs
@@ -83,6 +83,14 @@ public partial class LegacyHelper
             charmNailScaleMultiplier = Mathf.Clamp(charmNailScaleMultiplier * factor, 0.5f, 3f);
         }
 
+        internal void MultiplyNailKnockback(float factor)
+        {
+            if (factor <= 0f)
+                return;
+
+            charmNailKnockbackMultiplier = Mathf.Clamp(charmNailKnockbackMultiplier * factor, 0.1f, 5f);
+        }
+
         internal void AddSoulGainBonus(int amount)
         {
             charmSoulGainBonus = Mathf.Clamp(charmSoulGainBonus + amount, -99, 99);
@@ -101,6 +109,7 @@ public partial class LegacyHelper
             charmNailDamageMultiplier = 1f;
             charmSpellDamageMultiplier = 1f;
             charmNailScaleMultiplier = 1f;
+            charmNailKnockbackMultiplier = 1f;
             charmSoulGainBonus = 0;
             charmFocusHealBonus = 0;
             charmHornetFocusHealBonus = 0;
@@ -118,12 +127,16 @@ public partial class LegacyHelper
             focusHealingDisabled = false;
             carefreeMelodyChance = 0f;
             voidHeartEvadeActive = false;
+            sharpShadowEquipped = false;
+            sharpShadowDashActive = false;
+            sharpShadowDashHits.Clear();
             conditionalNailDamageMultipliers.Clear();
             conditionalNailDamageProduct = 1f;
             UpdateFocusDerivedValues();
             UpdateTeleportChannelTime();
             UpdateHurtIFrameDuration();
             ApplyCharmHealthModifiers(deferHudAndPersistence: true);
+            RefreshBaldurShellFocusState(immediate: true);
         }
 
         internal void GainShadeSoul(int amount)
@@ -209,6 +222,23 @@ public partial class LegacyHelper
             {
                 focusDamageShieldAbsorbedThisChannel = false;
             }
+
+            RefreshBaldurShellFocusState(immediate: !enabled);
+        }
+
+        internal void SetSharpShadowEnabled(bool enabled)
+        {
+            if (sharpShadowEquipped == enabled)
+            {
+                return;
+            }
+
+            sharpShadowEquipped = enabled;
+            if (!enabled)
+            {
+                sharpShadowDashActive = false;
+            }
+            sharpShadowDashHits.Clear();
         }
 
         internal void SetFocusHealingDisabled(bool disabled)
@@ -374,6 +404,15 @@ public partial class LegacyHelper
             {
                 UpdateConditionalNailDamageProduct();
             }
+        }
+
+        private int GetShadeNailDamage()
+        {
+            int nailDmg = Mathf.Max(1, GetHornetNailDamage());
+            nailDmg = Mathf.Max(1, Mathf.RoundToInt(nailDmg * ModConfig.Instance.shadeDamageMultiplier));
+            nailDmg = Mathf.Max(1, Mathf.RoundToInt(nailDmg * charmNailDamageMultiplier));
+            nailDmg = Mathf.Max(1, Mathf.RoundToInt(nailDmg * GetConditionalNailDamageMultiplier()));
+            return nailDmg;
         }
 
         private void UpdateConditionalNailDamageProduct()

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -96,6 +96,7 @@ public partial class LegacyHelper
         private Sprite[] dDiveSlamAnimFrames;
         private Sprite[] dDarkSlamAnimFrames;
         private Sprite[] dDarkBurstAnimFrames;
+        private Sprite[] baldurShellFocusAnimFrames;
         private Sprite inactiveSprite;
         private SpriteRenderer inactivePulseSr;
         private Sprite[] currentAnimFrames;
@@ -105,6 +106,7 @@ public partial class LegacyHelper
         private bool pendingSpawnAnimation;
         private bool isSpawning;
         private const float AnimFrameTime = 0.1f;
+        private const float BaldurShellFrameTime = 0.08f;
         private Vector2 lastMoveDelta;
         private Renderer[] shadeLightRenderers;
         public float simpleLightSize = 14f;
@@ -116,6 +118,10 @@ public partial class LegacyHelper
         private float nailTimer;
         internal static bool suppressActivateOnSlash;
         internal static Transform expectedSlashParent;
+        private SpriteRenderer baldurShellRenderer;
+        private Coroutine baldurShellRoutine;
+        private bool baldurShellActive;
+        private int baldurShellFrameIndex;
 
         private struct AxisLeashLimits
         {
@@ -168,6 +174,9 @@ public partial class LegacyHelper
         private ParticleSystem activeDashPs;
         private Vector2 activeDashDir;
         private bool voidHeartEvadeActive;
+        private bool sharpShadowEquipped;
+        private bool sharpShadowDashActive;
+        private readonly HashSet<HealthManager> sharpShadowDashHits = new HashSet<HealthManager>();
 
         private GameObject furyAuraObject;
         private ParticleSystem furyAuraPs;
@@ -187,6 +196,7 @@ public partial class LegacyHelper
         private float charmNailDamageMultiplier = 1f;
         private float charmSpellDamageMultiplier = 1f;
         private float charmNailScaleMultiplier = 1f;
+        private float charmNailKnockbackMultiplier = 1f;
         private int projectileSoulCost = s_defaultCharmStats.ProjectileSoulCost;
         private int shriekSoulCost = s_defaultCharmStats.ShriekSoulCost;
         private int quakeSoulCost = s_defaultCharmStats.QuakeSoulCost;

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -176,7 +176,8 @@ public partial class LegacyHelper
         private bool voidHeartEvadeActive;
         private bool sharpShadowEquipped;
         private bool sharpShadowDashActive;
-        private readonly HashSet<HealthManager> sharpShadowDashHits = new HashSet<HealthManager>();
+        private GameObject sharpShadowDashHitbox;
+        private ShadeAoE sharpShadowDashAoE;
 
         private GameObject furyAuraObject;
         private ParticleSystem furyAuraPs;

--- a/LegacyHelper.ShadeController.Slash.cs
+++ b/LegacyHelper.ShadeController.Slash.cs
@@ -263,10 +263,7 @@ public partial class LegacyHelper
                         fwd = (facing >= 0 ? Vector2.right : Vector2.left);
                     }
 
-                    int nailDmg = Mathf.Max(1, GetHornetNailDamage());
-                    nailDmg = Mathf.Max(1, Mathf.RoundToInt(nailDmg * ModConfig.Instance.shadeDamageMultiplier));
-                    nailDmg = Mathf.Max(1, Mathf.RoundToInt(nailDmg * charmNailDamageMultiplier));
-                    nailDmg = Mathf.Max(1, Mathf.RoundToInt(nailDmg * GetConditionalNailDamageMultiplier()));
+                    int nailDmg = GetShadeNailDamage();
                     foreach (var d in damagers)
                     {
                         if (!d) continue;
@@ -284,6 +281,7 @@ public partial class LegacyHelper
                         try { doesNotGenSilkField?.SetValue(d, true); } catch { }
                         try { useNailDmgField?.SetValue(d, false); } catch { }
                         try { damageDealtField?.SetValue(d, nailDmg); } catch { }
+                        try { d.magnitudeMult = Mathf.Max(0.01f, d.magnitudeMult * charmNailKnockbackMultiplier); } catch { }
                     }
 
                 }

--- a/Shade/ShadeCharmInventory.cs
+++ b/Shade/ShadeCharmInventory.cs
@@ -380,11 +380,19 @@ namespace LegacyoftheAbyss.Shade
                 enumId: ShadeCharmId.FragileStrength,
                 iconName: "shade_charm_fragile_strength"));
 
-            // TODO: Empower the shade's teleport to damage foes and extend its reach for Sharp Shadow.
             _definitions.Add(new ShadeCharmDefinition(
                 nameof(ShadeCharmId.SharpShadow),
+                statModifiers: new ShadeCharmStatModifiers
+                {
+                    SprintDashSpeedMultiplier = 1.4f
+                },
+                hooks: new ShadeCharmHooks
+                {
+                    OnApplied = ctx => ctx.Controller?.SetSharpShadowEnabled(true),
+                    OnRemoved = ctx => ctx.Controller?.SetSharpShadowEnabled(false)
+                },
                 displayName: "Sharp Shadow",
-                description: "Contains a forbidden spell that transforms shadows into deadly weapons. When using Shadow Dash, the bearer's body will sharpen and damage enemies.",
+                description: "Contains a forbidden spell that transforms shadows into deadly weapons. When using Shadow Dash, the bearer's body will sharpen, slice through foes, and surge forward faster.",
                 notchCost: 2,
                 fallbackTint: new Color(0.28f, 0.24f, 0.42f),
                 enumId: ShadeCharmId.SharpShadow,
@@ -431,8 +439,8 @@ namespace LegacyoftheAbyss.Shade
                 nameof(ShadeCharmId.HeavyBlow),
                 hooks: new ShadeCharmHooks
                 {
-                    OnApplied = ctx => ctx.Controller?.MultiplyKnockbackForce(1.4f),
-                    OnRemoved = ctx => ctx.Controller?.MultiplyKnockbackForce(1f / 1.4f)
+                    OnApplied = ctx => ctx.Controller?.MultiplyNailKnockback(1.4f),
+                    OnRemoved = ctx => ctx.Controller?.MultiplyNailKnockback(1f / 1.4f)
                 },
                 displayName: "Heavy Blow",
                 description: "Embues the shade's nail with tremendous force, sending foes staggering further with every strike.",


### PR DESCRIPTION
## Summary
- load the new Baldur Shell focus sprites and drive a focus-only shell animation that plays forward when channeling and reverses on completion
- route Heavy Blow through a dedicated nail knockback multiplier that is applied to all nail attacks
- implement Sharp Shadow by boosting dash speed, tracking dash collisions, and dealing nail damage when the shade passes through enemies

## Testing
- ⚠️ `dotnet test -c Release` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d59f2582c88320a6899ecda23414ab