### PR TITLE
Fix compass icon sprite and add Hiveblood regen preview

### DIFF
--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using LegacyoftheAbyss.Shade;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -48,6 +49,8 @@ public partial class SimpleHUD : MonoBehaviour
     private bool pendingMaskRefresh;
     private Image hivebloodPreviewMask;
     private bool hivebloodEquipped;
+    private ShadeCharmInventory subscribedCharmInventory;
+    private bool charmInventoryDirty;
 
     // UI containers
     private GameObject healthContainer;
@@ -94,7 +97,10 @@ public partial class SimpleHUD : MonoBehaviour
         LoadSprites();
         ComputeShadeFromPlayer();
         CreateUI();
+        SubscribeToCharmInventory();
+        charmInventoryDirty = true;
         previousShadeTotalHealth = shadeHealth + shadeLifeblood;
+        RefreshHealth();
     }
 
     private float GetUIScale()
@@ -106,6 +112,13 @@ public partial class SimpleHUD : MonoBehaviour
     private void Update()
     {
         UpdatePauseFade();
+        SubscribeToCharmInventory();
+
+        if (charmInventoryDirty && playerData != null)
+        {
+            charmInventoryDirty = false;
+            RefreshHealth();
+        }
 
         if (playerData == null) return;
 
@@ -349,6 +362,8 @@ public partial class SimpleHUD : MonoBehaviour
         if (pd == playerData) return;
         playerData = pd;
         int oldMax = shadeMax;
+        SubscribeToCharmInventory();
+        charmInventoryDirty = true;
         ComputeShadeFromPlayer();
         if (shadeMax != oldMax)
         {
@@ -357,6 +372,11 @@ public partial class SimpleHUD : MonoBehaviour
         }
         RefreshHealth();
         RefreshSoul();
+    }
+
+    private void OnDestroy()
+    {
+        UnsubscribeFromCharmInventory();
     }
 }
 

--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -14,12 +14,13 @@ public partial class SimpleHUD : MonoBehaviour
     private Image[] maskImages;
     private readonly HashSet<Image> animatingMaskImages = new HashSet<Image>();
     private Sprite maskSprite;
+    private Sprite hivebloodMaskSprite;
     private readonly Color missingMaskColor = new Color(0.2f, 0.2f, 0.2f, 0.45f);
     private readonly Color overcharmMaskColor = Color.white;
     private readonly Color overcharmBackdropColor = new Color(0.85f, 0.25f, 0.25f, 0.1344f);
     private readonly Color overcharmBackdropSpriteColor = new Color(1f, 1f, 1f, 0.392f);
     private readonly Color lifebloodMaskColor = new Color(0.4f, 0.75f, 1f, 1f);
-    private readonly Color hivebloodMaskColor = new Color(1f, 0.58f, 0.2f, 1f);
+    private readonly Color hivebloodMaskColor = new Color(1f, 0.72f, 0.18f, 1f);
     private readonly Color lifebloodMissingColor = new Color(0.28f, 0.46f, 0.66f, 0.45f);
 
     // Soul orb state

--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -45,6 +45,7 @@ public partial class SimpleHUD : MonoBehaviour
     private bool shadeAssistModeActive;
     private bool suppressNextDamageSound;
     private bool pendingMaskRefresh;
+    private Image hivebloodPreviewMask;
 
     // UI containers
     private GameObject healthContainer;
@@ -82,6 +83,8 @@ public partial class SimpleHUD : MonoBehaviour
     private const int OvercharmBackdropReferenceMaskCount = 3;
     private Vector2 overcharmMaskSize = Vector2.zero;
     private float overcharmMaskSpacing;
+    private const float HivebloodPreviewFirstStageSeconds = 3.5f;
+    private const float HivebloodPreviewSecondStageSeconds = 7f;
 
     public void Init(PlayerData pd)
     {

--- a/HUD.Core.cs
+++ b/HUD.Core.cs
@@ -18,6 +18,7 @@ public partial class SimpleHUD : MonoBehaviour
     private readonly Color overcharmBackdropColor = new Color(0.85f, 0.25f, 0.25f, 0.1344f);
     private readonly Color overcharmBackdropSpriteColor = new Color(1f, 1f, 1f, 0.392f);
     private readonly Color lifebloodMaskColor = new Color(0.4f, 0.75f, 1f, 1f);
+    private readonly Color hivebloodMaskColor = new Color(1f, 0.58f, 0.2f, 1f);
     private readonly Color lifebloodMissingColor = new Color(0.28f, 0.46f, 0.66f, 0.45f);
 
     // Soul orb state
@@ -46,6 +47,7 @@ public partial class SimpleHUD : MonoBehaviour
     private bool suppressNextDamageSound;
     private bool pendingMaskRefresh;
     private Image hivebloodPreviewMask;
+    private bool hivebloodEquipped;
 
     // UI containers
     private GameObject healthContainer;

--- a/HUD.UI.cs
+++ b/HUD.UI.cs
@@ -234,12 +234,20 @@ public partial class SimpleHUD
             suppressNextDamageSound = false;
         }
 
+        bool useHivebloodSprite = hivebloodEquipped && !shadeOvercharmed && hivebloodMaskSprite != null;
+        Sprite normalMaskSprite = useHivebloodSprite && hivebloodMaskSprite != null
+            ? hivebloodMaskSprite
+            : maskSprite;
+
         Color filledColor = GetNormalMaskFilledColor();
         for (int i = 0; i < normalMax && i < maskImages.Length; i++)
         {
             var img = maskImages[i];
             if (img == null) continue;
-            img.sprite = maskSprite != null ? maskSprite : img.sprite;
+            if (normalMaskSprite != null)
+            {
+                img.sprite = normalMaskSprite;
+            }
             img.color = i < currentNormal ? filledColor : missingMaskColor;
         }
 
@@ -249,7 +257,10 @@ public partial class SimpleHUD
             if (index >= maskImages.Length) break;
             var img = maskImages[index];
             if (img == null) continue;
-            img.sprite = maskSprite != null ? maskSprite : img.sprite;
+            if (maskSprite != null)
+            {
+                img.sprite = maskSprite;
+            }
             bool filled = i < currentLifeblood;
             if (filled)
             {
@@ -351,8 +362,14 @@ public partial class SimpleHUD
         Vector2 baseSize = targetRect.sizeDelta;
         previewRect.sizeDelta = baseSize * scale;
 
-        previewImage.sprite = maskSprite != null ? maskSprite : targetImage.sprite;
-        previewImage.color = GetNormalMaskFilledColor();
+        Sprite previewSprite = hivebloodMaskSprite
+            ?? maskSprite
+            ?? targetImage.sprite;
+        if (previewSprite != null)
+        {
+            previewImage.sprite = previewSprite;
+        }
+        previewImage.color = hivebloodMaskColor;
         previewImage.enabled = true;
         var previewGO = previewImage.gameObject;
         if (!previewGO.activeSelf)

--- a/HUD.UI.cs
+++ b/HUD.UI.cs
@@ -120,6 +120,9 @@ public partial class SimpleHUD
     {
         HandleAssistVisibilityChange();
 
+        var charms = ShadeRuntime.Charms;
+        hivebloodEquipped = charms != null && charms.IsEquipped(ShadeCharmId.Hiveblood);
+
         if (shadeAssistModeActive)
         {
             int total = Mathf.Max(0, shadeMax) + Mathf.Max(0, shadeLifebloodMax);
@@ -172,7 +175,7 @@ public partial class SimpleHUD
             {
                 if (i < 0 || i >= maskImages.Length) continue;
                 bool lifeblood = i >= normalMax;
-                StartCoroutine(LoseHealth(maskImages[i], shadeOvercharmed, lifeblood));
+                StartCoroutine(LoseHealth(maskImages[i], shadeOvercharmed, lifeblood, hivebloodEquipped));
             }
         }
         else if (suppressNextDamageSound)
@@ -180,7 +183,7 @@ public partial class SimpleHUD
             suppressNextDamageSound = false;
         }
 
-        Color filledColor = shadeOvercharmed ? overcharmMaskColor : Color.white;
+        Color filledColor = GetNormalMaskFilledColor();
         for (int i = 0; i < normalMax && i < maskImages.Length; i++)
         {
             var img = maskImages[i];
@@ -216,6 +219,16 @@ public partial class SimpleHUD
 
         RefreshHivebloodPreview();
         previousShadeTotalHealth = totalCurrent;
+    }
+
+    private Color GetNormalMaskFilledColor()
+    {
+        if (shadeOvercharmed)
+        {
+            return overcharmMaskColor;
+        }
+
+        return hivebloodEquipped ? hivebloodMaskColor : Color.white;
     }
 
     private void RefreshHivebloodPreview()
@@ -288,7 +301,7 @@ public partial class SimpleHUD
         previewRect.sizeDelta = baseSize * scale;
 
         previewImage.sprite = maskSprite != null ? maskSprite : targetImage.sprite;
-        previewImage.color = shadeOvercharmed ? overcharmMaskColor : Color.white;
+        previewImage.color = GetNormalMaskFilledColor();
         previewImage.enabled = true;
         var previewGO = previewImage.gameObject;
         if (!previewGO.activeSelf)
@@ -337,7 +350,7 @@ public partial class SimpleHUD
         }
     }
 
-    private IEnumerator LoseHealth(Image img, bool wasOvercharmed, bool wasLifeblood)
+    private IEnumerator LoseHealth(Image img, bool wasOvercharmed, bool wasLifeblood, bool hivebloodActive)
     {
         if (img == null) yield break;
 
@@ -355,7 +368,7 @@ public partial class SimpleHUD
         }
         else
         {
-            filledColor = wasOvercharmed ? overcharmMaskColor : Color.white;
+            filledColor = wasOvercharmed ? overcharmMaskColor : (hivebloodActive ? hivebloodMaskColor : Color.white);
             flickerColor = wasOvercharmed ? filledColor : Color.red;
             emptyColor = missingMaskColor;
         }

--- a/HUD.UI.cs
+++ b/HUD.UI.cs
@@ -7,6 +7,57 @@ using UnityEngine.UI;
 
 public partial class SimpleHUD
 {
+    private void SubscribeToCharmInventory()
+    {
+        var inventory = ShadeRuntime.Charms;
+        if (inventory == null)
+        {
+            UnsubscribeFromCharmInventory();
+            return;
+        }
+
+        if (subscribedCharmInventory == inventory)
+        {
+            return;
+        }
+
+        UnsubscribeFromCharmInventory();
+
+        subscribedCharmInventory = inventory;
+        try
+        {
+            subscribedCharmInventory.StateChanged += HandleCharmInventoryChanged;
+            charmInventoryDirty = true;
+        }
+        catch
+        {
+            subscribedCharmInventory = null;
+        }
+    }
+
+    private void UnsubscribeFromCharmInventory()
+    {
+        if (subscribedCharmInventory == null)
+        {
+            return;
+        }
+
+        try
+        {
+            subscribedCharmInventory.StateChanged -= HandleCharmInventoryChanged;
+        }
+        catch
+        {
+        }
+
+        subscribedCharmInventory = null;
+    }
+
+    private void HandleCharmInventoryChanged()
+    {
+        charmInventoryDirty = true;
+    }
+
     private void CreateUI()
     {
         // Canvas

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -1970,6 +1970,7 @@ public partial class LegacyHelper
         private static readonly MethodInfo IsLostInAbyssMethod = AccessTools.Method(typeof(GameMap), "IsLostInAbyssPreMap");
 
         private static GameObject shadeCompassIcon;
+        private static GameObject templateCompassIcon;
         private static Sprite shadeCompassSprite;
         private static bool loggedFailure;
 
@@ -2068,12 +2069,37 @@ public partial class LegacyHelper
 
         private static GameObject EnsureIcon(GameMap map)
         {
+            var template = CompassIconField?.GetValue(map) as GameObject;
+            if (template != null)
+            {
+                templateCompassIcon = template;
+            }
+
             if (shadeCompassIcon != null)
             {
+                if (CompassIconField != null)
+                {
+                    try
+                    {
+                        var activeIcon = CompassIconField.GetValue(map) as GameObject;
+                        if (activeIcon != shadeCompassIcon)
+                        {
+                            CompassIconField.SetValue(map, shadeCompassIcon);
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                if (templateCompassIcon != null && templateCompassIcon != shadeCompassIcon)
+                {
+                    try { templateCompassIcon.SetActive(false); } catch { }
+                }
+
                 return shadeCompassIcon;
             }
 
-            var template = CompassIconField?.GetValue(map) as GameObject;
             if (template == null)
             {
                 return null;
@@ -2104,17 +2130,14 @@ public partial class LegacyHelper
                         continue;
                     }
 
-                    if (templateSprite == null || renderer.sprite == templateSprite)
+                    renderer.sprite = sprite;
+                    if (templateRenderer != null)
                     {
-                        renderer.sprite = sprite;
-                        if (templateRenderer != null)
-                        {
-                            renderer.sortingLayerID = templateRenderer.sortingLayerID;
-                            renderer.sortingOrder = templateRenderer.sortingOrder;
-                            renderer.color = templateRenderer.color;
-                            renderer.flipX = templateRenderer.flipX;
-                            renderer.flipY = templateRenderer.flipY;
-                        }
+                        renderer.sortingLayerID = templateRenderer.sortingLayerID;
+                        renderer.sortingOrder = templateRenderer.sortingOrder;
+                        renderer.color = templateRenderer.color;
+                        renderer.flipX = templateRenderer.flipX;
+                        renderer.flipY = templateRenderer.flipY;
                     }
                 }
 
@@ -2125,6 +2148,15 @@ public partial class LegacyHelper
             }
 
             shadeCompassIcon = clone;
+            if (CompassIconField != null)
+            {
+                try { CompassIconField.SetValue(map, shadeCompassIcon); } catch { }
+            }
+
+            if (templateCompassIcon != null && templateCompassIcon != shadeCompassIcon)
+            {
+                try { templateCompassIcon.SetActive(false); } catch { }
+            }
             return shadeCompassIcon;
         }
 

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -2084,18 +2084,43 @@ public partial class LegacyHelper
             clone.name = "ShadeCompassIcon";
             clone.SetActive(false);
 
-            var templateRenderer = template.GetComponent<SpriteRenderer>();
-            var cloneRenderer = clone.GetComponent<SpriteRenderer>();
-            if (cloneRenderer != null)
+            var templateRenderer = template.GetComponentInChildren<SpriteRenderer>(true);
+            var templateSprite = templateRenderer != null ? templateRenderer.sprite : null;
+            var cloneRenderers = clone.GetComponentsInChildren<SpriteRenderer>(true);
+
+            var sprite = ResolveSprite(templateRenderer);
+            if (sprite != null)
             {
-                var sprite = ResolveSprite(templateRenderer);
-                if (sprite != null)
+                if (cloneRenderers == null || cloneRenderers.Length == 0)
                 {
-                    cloneRenderer.sprite = sprite;
-                    if (templateRenderer != null && templateRenderer.sprite != null)
+                    var newRenderer = clone.AddComponent<SpriteRenderer>();
+                    cloneRenderers = new[] { newRenderer };
+                }
+
+                foreach (var renderer in cloneRenderers)
+                {
+                    if (renderer == null)
                     {
-                        MatchScale(clone.transform, templateRenderer.sprite, sprite);
+                        continue;
                     }
+
+                    if (templateSprite == null || renderer.sprite == templateSprite)
+                    {
+                        renderer.sprite = sprite;
+                        if (templateRenderer != null)
+                        {
+                            renderer.sortingLayerID = templateRenderer.sortingLayerID;
+                            renderer.sortingOrder = templateRenderer.sortingOrder;
+                            renderer.color = templateRenderer.color;
+                            renderer.flipX = templateRenderer.flipX;
+                            renderer.flipY = templateRenderer.flipY;
+                        }
+                    }
+                }
+
+                if (templateRenderer != null && templateSprite != null)
+                {
+                    MatchScale(clone.transform, templateSprite, sprite);
                 }
             }
 

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -2001,13 +2001,7 @@ public partial class LegacyHelper
         private static bool attemptedImageConversionLookup;
         private static bool attemptedTextureLoadImageLookup;
 
-        private sealed class ShadeCompassIconMarker : MonoBehaviour
-        {
-            internal GameObject Template;
-            internal Transform TemplateTransform;
-        }
-
-        private static GameObject EnsureQuickMapIcon(GameMap map)
+        private static GameObject GetQuickMapIcon(GameMap map)
         {
             if (CompassIconField == null)
             {
@@ -2019,71 +2013,10 @@ public partial class LegacyHelper
                 return null;
             }
 
-            if (!icon.TryGetComponent(out ShadeCompassIconMarker marker))
-            {
-                var replacement = CreateQuickMapIcon(icon);
-                if (replacement != null)
-                {
-                    try
-                    {
-                        CompassIconField.SetValue(map, replacement);
-                    }
-                    catch
-                    {
-                    }
-                    return replacement;
-                }
-
-                return icon;
-            }
-
-            if (marker.Template != null && marker.Template.activeSelf)
-            {
-                marker.Template.SetActive(false);
-            }
-
             return icon;
         }
 
-        private static GameObject CreateQuickMapIcon(GameObject template)
-        {
-            if (template == null)
-            {
-                return null;
-            }
-
-            GameObject clone;
-            try
-            {
-                clone = UnityEngine.Object.Instantiate(template, template.transform.parent);
-            }
-            catch
-            {
-                return null;
-            }
-
-            clone.name = "ShadeCompassIcon";
-            clone.transform.localPosition = template.transform.localPosition;
-            clone.transform.localRotation = template.transform.localRotation;
-            clone.transform.localScale = template.transform.localScale;
-
-            DisableBehaviours(clone);
-
-            var marker = clone.AddComponent<ShadeCompassIconMarker>();
-            marker.Template = template;
-            marker.TemplateTransform = template.transform;
-
-            ApplySprite(clone);
-
-            if (template.activeSelf)
-            {
-                template.SetActive(false);
-            }
-
-            return clone;
-        }
-
-        private static Transform EnsureWideMapIcon(InventoryWideMap wideMap)
+        private static Transform GetWideMapIcon(InventoryWideMap wideMap)
         {
             if (WideMapCompassIconField == null)
             {
@@ -2095,102 +2028,7 @@ public partial class LegacyHelper
                 return null;
             }
 
-            if (!icon.TryGetComponent(out ShadeCompassIconMarker marker))
-            {
-                var replacement = CreateWideMapIcon(icon);
-                if (replacement != null)
-                {
-                    try
-                    {
-                        WideMapCompassIconField.SetValue(wideMap, replacement);
-                    }
-                    catch
-                    {
-                    }
-                    return replacement;
-                }
-
-                return icon;
-            }
-
-            if (marker.TemplateTransform != null && marker.TemplateTransform.gameObject.activeSelf)
-            {
-                marker.TemplateTransform.gameObject.SetActive(false);
-            }
-
             return icon;
-        }
-
-        private static Transform CreateWideMapIcon(Transform template)
-        {
-            if (template == null)
-            {
-                return null;
-            }
-
-            GameObject clone;
-            try
-            {
-                clone = UnityEngine.Object.Instantiate(template.gameObject, template.parent);
-            }
-            catch
-            {
-                return null;
-            }
-
-            clone.name = "ShadeCompassWideIcon";
-            var cloneTransform = clone.transform;
-            cloneTransform.localPosition = template.localPosition;
-            cloneTransform.localRotation = template.localRotation;
-            cloneTransform.localScale = template.localScale;
-
-            if (template is RectTransform templateRect && cloneTransform is RectTransform cloneRect)
-            {
-                cloneRect.anchorMin = templateRect.anchorMin;
-                cloneRect.anchorMax = templateRect.anchorMax;
-                cloneRect.pivot = templateRect.pivot;
-                cloneRect.sizeDelta = templateRect.sizeDelta;
-                cloneRect.anchoredPosition = templateRect.anchoredPosition;
-            }
-
-            DisableBehaviours(clone);
-
-            var marker = clone.AddComponent<ShadeCompassIconMarker>();
-            marker.Template = template.gameObject;
-            marker.TemplateTransform = template;
-
-            ApplySprite(clone);
-
-            if (template.gameObject.activeSelf)
-            {
-                template.gameObject.SetActive(false);
-            }
-
-            return cloneTransform;
-        }
-
-        private static void DisableBehaviours(GameObject root)
-        {
-            if (root == null)
-            {
-                return;
-            }
-
-            var behaviours = root.GetComponentsInChildren<Behaviour>(true);
-            foreach (var behaviour in behaviours)
-            {
-                if (behaviour == null)
-                {
-                    continue;
-                }
-
-                if (behaviour is Graphic || behaviour is Canvas || behaviour is CanvasGroup || behaviour is RectMask2D)
-                {
-                    continue;
-                }
-
-                behaviour.enabled = false;
-            }
         }
 
         private static Sprite GetTemplateSprite(GameObject iconRoot, out float pixelsPerUnit)
@@ -2199,19 +2037,6 @@ public partial class LegacyHelper
             if (iconRoot == null)
             {
                 return null;
-            }
-
-            GameObject source = null;
-            var marker = iconRoot.GetComponent<ShadeCompassIconMarker>();
-            if (marker != null)
-            {
-                source = marker.Template != null ? marker.Template : marker.TemplateTransform != null ? marker.TemplateTransform.gameObject : null;
-            }
-
-            var sprite = ExtractSprite(source, out pixelsPerUnit);
-            if (sprite != null)
-            {
-                return sprite;
             }
 
             return ExtractSprite(iconRoot, out pixelsPerUnit);
@@ -2253,7 +2078,7 @@ public partial class LegacyHelper
                 return;
             }
 
-            var icon = EnsureQuickMapIcon(map);
+            var icon = GetQuickMapIcon(map);
             if (icon == null)
             {
                 return;
@@ -2298,7 +2123,7 @@ public partial class LegacyHelper
                 return;
             }
 
-            var icon = EnsureWideMapIcon(wideMap);
+            var icon = GetWideMapIcon(wideMap);
             if (icon == null)
             {
                 return;

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -2569,6 +2569,25 @@ public partial class LegacyHelper
                     image.enabled = true;
                 }
             }
+
+            var spriteMasks = iconRoot.GetComponentsInChildren<SpriteMask>(true);
+            if (spriteMasks != null && spriteMasks.Length > 0)
+            {
+                foreach (var mask in spriteMasks)
+                {
+                    if (mask == null)
+                    {
+                        continue;
+                    }
+
+                    if (mask.sprite == sprite)
+                    {
+                        continue;
+                    }
+
+                    mask.sprite = sprite;
+                }
+            }
         }
 
         private static Sprite ResolveSprite(Sprite templateSprite, float fallbackPixelsPerUnit)


### PR DESCRIPTION
## Summary
- ensure the shade compass pin swaps every SpriteRenderer clone to the Shade_Pin asset and preserves template renderer settings
- expose Hiveblood regeneration state from the charm inventory and add a HUD overlay that grows in stages to show the pending mask restoration

## Testing
- `dotnet build -c Release` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cd8f25248320b49b72b4c0692800