### PR TITLE
Force Void Heart to remain equipped outside debug mode

### DIFF
--- a/Shade/ShadeRuntime.cs
+++ b/Shade/ShadeRuntime.cs
@@ -404,6 +404,18 @@ namespace LegacyoftheAbyss.Shade
             return true;
         }
 
+        internal static bool IsDebugCharmModeActive()
+        {
+            EnsureActiveSlot();
+
+            if (s_debugUnlockAllCharmsActive)
+            {
+                return true;
+            }
+
+            return s_saveSlots.IsDebugUnlockActive(s_activeSlot);
+        }
+
         internal static IReadOnlyCollection<ShadeCharmId> GetCollectedCharms()
         {
             EnsureActiveSlot();


### PR DESCRIPTION
## Summary
- ensure Void Heart is automatically equipped and pinned to the first slot whenever it is owned outside of debug mode
- expose a runtime helper to detect when the debug charm loadout is active
- expand shade charm inventory tests to cover Void Heart auto-equip and debug unequip behaviour

## Testing
- not run (dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d61555d8cc8320877ab88afd2d54e4