### PR TITLE
Re-enable shade damage console logging

### DIFF
--- a/LegacyHelper.Core.cs
+++ b/LegacyHelper.Core.cs
@@ -71,7 +71,7 @@ public partial class LegacyHelper : BaseUnityPlugin
     {
         Instance = this;
         ModConfig.Load();
-        LoggingManager.Initialize();
+        LoggingManager.Initialize(Logger);
         var harmony = new Harmony("com.legacyoftheabyss.helper");
         harmony.PatchAll();
 

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -2229,9 +2229,25 @@ public partial class LegacyHelper
                     bool canDamage = false;
                     try { canDamage = dh.enabled && dh.CanCauseDamage; } catch { }
                     if (!canDamage) { LogShadeDamage(dh, col, false); return; }
+                    int dmg = GetDamageAmount(dh);
                     var hz = GetHazardType(dh);
-                    if (IsTerrainHazard(hz)) { LogShadeDamage(dh, col, canTakeDamage); OnShadeHitHazard(); return; }
-                    int dmg = 0; try { dmg = dh.damageDealt; } catch { }
+                    if (hz == GlobalEnums.HazardType.STEAM && dmg <= 0)
+                    {
+                        LogShadeDamage(dh, col, false);
+                        return;
+                    }
+                    if (IsTerrainHazard(hz))
+                    {
+                        if (dmg <= 0)
+                        {
+                            LogShadeDamage(dh, col, false);
+                            return;
+                        }
+
+                        LogShadeDamage(dh, col, canTakeDamage);
+                        OnShadeHitHazard();
+                        return;
+                    }
                     if (dmg > 0)
                     {
                         bool preventedByVoidHeart = IsVoidHeartEvading();
@@ -2618,15 +2634,23 @@ public partial class LegacyHelper
                         continue;
                     }
 
+                    int dmg = GetDamageAmount(dh);
                     var hz = GetHazardType(dh);
+                    if (hz == GlobalEnums.HazardType.STEAM && dmg <= 0)
+                    {
+                        continue;
+                    }
+
                     if (IsTerrainHazard(hz))
                     {
+                        if (dmg <= 0)
+                        {
+                            continue;
+                        }
+
                         return true;
                     }
 
-                    int dmg = 0;
-                    try { dmg = dh.damageDealt; }
-                    catch { }
                     if (dmg > 0)
                     {
                         return true;
@@ -2710,13 +2734,42 @@ public partial class LegacyHelper
                     bool canDamage = false;
                     try { canDamage = dh.enabled && dh.CanCauseDamage; } catch { }
                     if (!canDamage) { LogShadeDamage(dh, c, false); continue; }
+                    int dmg = GetDamageAmount(dh);
                     var hz = GetHazardType(dh);
-                    if (IsTerrainHazard(hz)) { LogShadeDamage(dh, c, canTakeDamage); OnShadeHitHazard(); return; }
-                    int dmg = 0; try { dmg = dh.damageDealt; } catch { }
+                    if (hz == GlobalEnums.HazardType.STEAM && dmg <= 0)
+                    {
+                        LogShadeDamage(dh, c, false);
+                        continue;
+                    }
+                    if (IsTerrainHazard(hz))
+                    {
+                        if (dmg <= 0)
+                        {
+                            LogShadeDamage(dh, c, false);
+                            continue;
+                        }
+
+                        LogShadeDamage(dh, c, canTakeDamage);
+                        OnShadeHitHazard();
+                        return;
+                    }
                     if (dmg > 0) { LogShadeDamage(dh, c, canTakeDamage); OnShadeHitEnemy(dh); return; }
                     LogShadeDamage(dh, c, false);
                 }
             }
+        }
+
+        private static int GetDamageAmount(DamageHero dh)
+        {
+            if (!dh)
+            {
+                return 0;
+            }
+
+            try { return dh.damageDealt; }
+            catch { }
+
+            return 0;
         }
 
         private static GlobalEnums.HazardType GetHazardType(DamageHero dh)
@@ -2802,8 +2855,7 @@ public partial class LegacyHelper
         private void OnShadeHitEnemy(DamageHero dh)
         {
             if (hurtCooldown > 0f) return;
-            int dmg = 0;
-            try { if (dh != null) dmg = dh.damageDealt; } catch { }
+            int dmg = GetDamageAmount(dh);
             dmg = ApplyOvercharmPenalty(dmg);
             if (dmg <= 0)
             {

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -59,7 +59,7 @@ public partial class LegacyHelper
         private float battleCheckTimer;
 
         private static readonly string[] IgnoreDamageTokens =
-            {"alert range", "attack range", "wake", "close range", "sight range", "terrain", "range", "physics pusher"};
+            {"alert range", "attack range", "wake", "close range", "sight range", "terrain", "range", "physics pusher", "bounce collider"};
 
         // Ranged attack
         public float projectileSpeed = 22f;

--- a/LegacyHelper.ShadeController.Slash.cs
+++ b/LegacyHelper.ShadeController.Slash.cs
@@ -1068,7 +1068,8 @@ public partial class LegacyHelper
             bool flip = dir.x < 0f;
             psr.flipX = flip;
 
-            float scale = SpriteScale * (IsProjectileUpgraded() ? 1.5f : 1f) * 1.6f;
+            const float shadeSoulScaleMultiplier = 1.6f * 0.7f; // reduce projectile size by 30%
+            float scale = SpriteScale * (IsProjectileUpgraded() ? 1.5f : 1f) * shadeSoulScaleMultiplier;
             proj.transform.localScale = Vector3.one * scale;
 
             Collider2D[] projCols;

--- a/LoggingManager.cs
+++ b/LoggingManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using BepInEx.Logging;
 using UnityEngine;
 
 internal static class LoggingManager
@@ -13,13 +14,18 @@ internal static class LoggingManager
     }
 
     private static readonly Dictionary<string, DamageEntry> damage = new();
+    private static ManualLogSource consoleLogger;
     private static string logFile;
     private static bool wroteHitHeader;
     private static bool wroteBlockedHeader;
     private static bool initialized;
 
-    internal static void Initialize()
+    internal static void Initialize(ManualLogSource logger = null)
     {
+        if (logger != null)
+        {
+            consoleLogger = logger;
+        }
         if (initialized) return;
         initialized = true;
         try
@@ -35,19 +41,18 @@ internal static class LoggingManager
     {
         try
         {
-            var logger = LegacyHelper.Instance?.Logger;
-            if (logger != null)
+            if (consoleLogger != null)
             {
                 string message = succeeded
                     ? $"Shade took damage from {source}."
                     : $"Shade avoided damage from {source}.";
                 if (succeeded)
                 {
-                    logger.LogWarning(message);
+                    consoleLogger.LogWarning(message);
                 }
                 else
                 {
-                    logger.LogInfo(message);
+                    consoleLogger.LogInfo(message);
                 }
             }
         }

--- a/LoggingManager.cs
+++ b/LoggingManager.cs
@@ -33,6 +33,28 @@ internal static class LoggingManager
 
     internal static void LogShadeDamage(string source, bool succeeded)
     {
+        try
+        {
+            var logger = LegacyHelper.Instance?.Logger;
+            if (logger != null)
+            {
+                string message = succeeded
+                    ? $"Shade took damage from {source}."
+                    : $"Shade avoided damage from {source}.";
+                if (succeeded)
+                {
+                    logger.LogWarning(message);
+                }
+                else
+                {
+                    logger.LogInfo(message);
+                }
+            }
+        }
+        catch
+        {
+        }
+
         if (!ModConfig.Instance.logDamage) return;
         Initialize();
         if (!damage.TryGetValue(source, out var entry))

--- a/Shade/ShadeCharmPlacementDefinition.cs
+++ b/Shade/ShadeCharmPlacementDefinition.cs
@@ -101,8 +101,9 @@ namespace LegacyoftheAbyss.Shade
 
             if (hasContains)
             {
+                string[] requiredTokens = SceneContainsAll!;
                 bool containsAll = true;
-                foreach (string token in SceneContainsAll)
+                foreach (string token in requiredTokens)
                 {
                     if (string.IsNullOrWhiteSpace(token))
                     {
@@ -118,9 +119,9 @@ namespace LegacyoftheAbyss.Shade
 
                 if (containsAll)
                 {
-                    if (SceneExcludesAny != null && SceneExcludesAny.Length > 0)
+                    if (SceneExcludesAny is { Length: > 0 } excludedTokens)
                     {
-                        foreach (string exclude in SceneExcludesAny)
+                        foreach (string exclude in excludedTokens)
                         {
                             if (string.IsNullOrWhiteSpace(exclude))
                             {


### PR DESCRIPTION
## Summary
- add console messages when the shade takes or avoids damage so sources are visible during play

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6dc91c7848320b6c177b46f8a3c41