### PR TITLE
Reassign boss charm drops for Fourth Chorus and Lost Garmond

### DIFF
--- a/Assets/charm_placements.json
+++ b/Assets/charm_placements.json
@@ -78,13 +78,6 @@
       "notes": "Requested Grubberfly's Elegy placement"
     },
     {
-      "sceneName": "Slab_14",
-      "placementKind": "Ground",
-      "charmId": "HeavyBlow",
-      "worldPosition": { "x": 11.052, "y": 3.569, "z": 0.004 },
-      "notes": "Requested Heavy Blow placement"
-    },
-    {
       "sceneName": "Coral_38",
       "placementKind": "Ground",
       "charmId": "BaldurShell",
@@ -111,6 +104,13 @@
       "charmId": "JonisBlessing",
       "worldPosition": { "x": 38.159, "y": 8.568, "z": 0.004 },
       "notes": "Requested Joni's Blessing placement"
+    },
+    {
+      "sceneName": "Slab_14",
+      "placementKind": "Ground",
+      "charmId": "HeavyBlow",
+      "worldPosition": { "x": 11.052, "y": 3.569, "z": 0.004 },
+      "notes": "Requested Heavy Blow placement"
     },
     {
       "sceneName": "Song_09b",
@@ -167,12 +167,6 @@
       "charmId": "ShapeOfUnn",
       "worldPosition": { "x": 33.831, "y": 20.568, "z": 0.004 },
       "notes": "Requested Shape of Unn placement"
-    },
-    {
-      "sceneContainsAll": ["bone", "bottom"],
-      "placementKind": "GroundAnchor",
-      "charmId": "SteadyBody",
-      "anchorOffset": { "x": -2.6, "y": -0.7, "z": 0.0 }
     },
     {
       "sceneContainsAll": ["bone", "bottom"],
@@ -276,6 +270,22 @@
         "geoCost": 200
       },
       "notes": "Stalwart Shell sold by the Forge Daughter"
+    },
+    {
+      "placementKind": "BossDrop",
+      "charmId": "SteadyBody",
+      "bossDrop": {
+        "enemyNameContainsAll": ["Song", "Golem"]
+      },
+      "notes": "Steady Body dropped by the Fourth Chorus"
+    },
+    {
+      "placementKind": "BossDrop",
+      "charmId": "FragileStrength",
+      "bossDrop": {
+        "enemyNameContainsAll": ["Lost", "Garmond"]
+      },
+      "notes": "Fragile Strength dropped by Lost Garmond"
     }
   ]
 }

--- a/Shade/ShadeRuntime.cs
+++ b/Shade/ShadeRuntime.cs
@@ -109,6 +109,7 @@ namespace LegacyoftheAbyss.Shade
         internal static void HandleSceneEntered(string? sceneName)
         {
             EnsureActiveSlot();
+            TryGrantBossDropCharms();
             TryGrantVoidHeartForScene(sceneName);
         }
 
@@ -591,6 +592,37 @@ namespace LegacyoftheAbyss.Shade
             }
 
             QueueVoidHeartUnlockNotification();
+        }
+
+        private static void TryGrantBossDropCharms()
+        {
+            PlayerData? playerData;
+            try
+            {
+                playerData = GameManager.instance?.playerData;
+            }
+            catch
+            {
+                return;
+            }
+
+            if (playerData == null)
+            {
+                return;
+            }
+
+            TryGrantCharmFromFlag(playerData.defeatedSongGolem, ShadeCharmId.SteadyBody);
+            TryGrantCharmFromFlag(playerData.garmondBlackThreadDefeated, ShadeCharmId.FragileStrength);
+        }
+
+        private static void TryGrantCharmFromFlag(bool flag, ShadeCharmId charmId)
+        {
+            if (!flag)
+            {
+                return;
+            }
+
+            TryCollectCharm(charmId);
         }
 
         private static void QueueVoidHeartUnlockNotification()


### PR DESCRIPTION
## Summary
- remove the ground placement for Steady Body and hook it into the Fourth Chorus boss drop instead
- grant Fragile Strength from the Lost Garmond boss fight and update scene-entry backfill to match
- restore the Carefree Melody and Heavy Blow ground placements as requested

## Testing
- not run (dotnet CLI is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d6d47597748320b7a2bbcfa1bbe20e