### PR TITLE
Add hero-layer aggro proxy for shade

### DIFF
--- a/LegacyHelper.Core.cs
+++ b/LegacyHelper.Core.cs
@@ -30,6 +30,28 @@ public partial class LegacyHelper : BaseUnityPlugin
 
     internal static LegacyHelper Instance { get; private set; }
 
+    internal static void LogInfo(string message)
+    {
+        try
+        {
+            Instance?.Logger?.LogInfo(message);
+        }
+        catch
+        {
+        }
+    }
+
+    internal static void LogWarning(string message)
+    {
+        try
+        {
+            Instance?.Logger?.LogWarning(message);
+        }
+        catch
+        {
+        }
+    }
+
     // Persist shade state across scene transitions
     internal static bool HasSavedShadeState => ShadeRuntime.PersistentState.HasData;
 

--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -67,6 +67,29 @@ public partial class LegacyHelper
         }
     }
 
+    [HarmonyPatch(typeof(TrackTriggerObjects), "OnTriggerEnter2D")]
+    private static class TrackTriggerObjects_OnTriggerEnter2D_Patch
+    {
+        private static bool Prefix(TrackTriggerObjects __instance, Collider2D collision)
+        {
+            if (__instance is CameraLockArea && collision)
+            {
+                try
+                {
+                    if (collision.GetComponent<ShadeController.AggroProxyTracker>() != null)
+                    {
+                        return false;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            return true;
+        }
+    }
+
     [HarmonyPatch(typeof(AlertRange), "FixedUpdate")]
     internal static class AlertRange_FixedUpdate_Patch
     {

--- a/LegacyHelper.ShadeAggroTracker.cs
+++ b/LegacyHelper.ShadeAggroTracker.cs
@@ -46,7 +46,7 @@ internal static class ShadeAggroTracker
             try
             {
                 string owner = GetOwnerName(alertRange);
-                LegacyHelper.Instance?.Logger?.LogInfo($"Shade aggro proxy entered alert range '{alertRange.name}' ({owner}).");
+                LegacyHelper.LogInfo($"Shade aggro proxy entered alert range '{alertRange.name}' ({owner}).");
             }
             catch
             {
@@ -192,7 +192,7 @@ internal static class ShadeAggroTracker
             try
             {
                 string owner = GetOwnerName(range);
-                LegacyHelper.Instance?.Logger?.LogInfo($"Shade aggro proxy exited alert range '{range.name}' ({owner}).");
+                LegacyHelper.LogInfo($"Shade aggro proxy exited alert range '{range.name}' ({owner}).");
             }
             catch
             {

--- a/LegacyHelper.ShadeAggroTracker.cs
+++ b/LegacyHelper.ShadeAggroTracker.cs
@@ -1,0 +1,248 @@
+#nullable disable
+using System.Collections.Generic;
+using UnityEngine;
+
+internal static class ShadeAggroTracker
+{
+    internal readonly struct Target
+    {
+        public Target(LegacyHelper.ShadeController shade, LegacyHelper.ShadeController.AggroProxyTracker proxy, Vector2 position)
+        {
+            Shade = shade;
+            Proxy = proxy;
+            Position = position;
+        }
+
+        public LegacyHelper.ShadeController Shade { get; }
+        public LegacyHelper.ShadeController.AggroProxyTracker Proxy { get; }
+        public Vector2 Position { get; }
+    }
+
+    private static readonly Dictionary<AlertRange, HashSet<LegacyHelper.ShadeController.AggroProxyTracker>> RangeToProxies = new();
+    private static readonly Dictionary<LegacyHelper.ShadeController.AggroProxyTracker, HashSet<AlertRange>> ProxyToRanges = new();
+    private static readonly List<AlertRange> RangeRemovalBuffer = new();
+
+    internal static void NotifyEntered(LegacyHelper.ShadeController.AggroProxyTracker proxy, TrackTriggerObjects enteredRange)
+    {
+        if (proxy == null || enteredRange == null)
+        {
+            return;
+        }
+
+        if (enteredRange is not AlertRange alertRange)
+        {
+            return;
+        }
+
+        if (!proxy.IsEligibleForAggro)
+        {
+            return;
+        }
+
+        Register(alertRange, proxy);
+
+        if (ModConfig.Instance.logShade)
+        {
+            try
+            {
+                string owner = GetOwnerName(alertRange);
+                LegacyHelper.Instance?.Logger?.LogInfo($"Shade aggro proxy entered alert range '{alertRange.name}' ({owner}).");
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    internal static void NotifyExited(LegacyHelper.ShadeController.AggroProxyTracker proxy, TrackTriggerObjects exitedRange)
+    {
+        if (proxy == null || exitedRange == null)
+        {
+            return;
+        }
+
+        if (exitedRange is AlertRange alertRange)
+        {
+            Remove(alertRange, proxy, log: true);
+        }
+    }
+
+    internal static void NotifyDisabled(LegacyHelper.ShadeController.AggroProxyTracker proxy)
+    {
+        if (proxy == null)
+        {
+            return;
+        }
+
+        if (!ProxyToRanges.TryGetValue(proxy, out var ranges) || ranges.Count == 0)
+        {
+            ProxyToRanges.Remove(proxy);
+            return;
+        }
+
+        RangeRemovalBuffer.Clear();
+        RangeRemovalBuffer.AddRange(ranges);
+        foreach (var range in RangeRemovalBuffer)
+        {
+            Remove(range, proxy, log: false);
+        }
+        ProxyToRanges.Remove(proxy);
+    }
+
+    internal static bool TryGetTargets(AlertRange range, List<Target> buffer)
+    {
+        buffer.Clear();
+        if (range == null)
+        {
+            return false;
+        }
+
+        Cleanup(range);
+        if (!RangeToProxies.TryGetValue(range, out var proxies) || proxies.Count == 0)
+        {
+            return false;
+        }
+
+        bool removedNullProxy = false;
+        foreach (var proxy in proxies)
+        {
+            if (proxy == null)
+            {
+                removedNullProxy = true;
+                continue;
+            }
+
+            if (!proxy.IsEligibleForAggro)
+            {
+                continue;
+            }
+
+            if (!proxy.TryGetOwner(out var shade) || shade == null || !shade.IsAggroEligible)
+            {
+                continue;
+            }
+
+            if (!proxy.TryGetTargetPoint(out var target))
+            {
+                continue;
+            }
+
+            buffer.Add(new Target(shade, proxy, target));
+        }
+
+        if (removedNullProxy)
+        {
+            proxies.RemoveWhere(p => p == null);
+            if (proxies.Count == 0)
+            {
+                RangeToProxies.Remove(range);
+                LegacyHelper.AlertRange_FixedUpdate_Patch.ResetLog(range);
+            }
+        }
+
+        return buffer.Count > 0;
+    }
+
+    private static void Register(AlertRange range, LegacyHelper.ShadeController.AggroProxyTracker proxy)
+    {
+        Cleanup(range);
+        if (!RangeToProxies.TryGetValue(range, out var proxies))
+        {
+            proxies = new HashSet<LegacyHelper.ShadeController.AggroProxyTracker>();
+            RangeToProxies[range] = proxies;
+        }
+        proxies.Add(proxy);
+
+        if (!ProxyToRanges.TryGetValue(proxy, out var ranges))
+        {
+            ranges = new HashSet<AlertRange>();
+            ProxyToRanges[proxy] = ranges;
+        }
+        ranges.Add(range);
+    }
+
+    private static void Remove(AlertRange range, LegacyHelper.ShadeController.AggroProxyTracker proxy, bool log)
+    {
+        if (range == null || proxy == null)
+        {
+            return;
+        }
+
+        if (RangeToProxies.TryGetValue(range, out var proxies))
+        {
+            proxies.Remove(proxy);
+            if (proxies.Count == 0)
+            {
+                RangeToProxies.Remove(range);
+                LegacyHelper.AlertRange_FixedUpdate_Patch.ResetLog(range);
+            }
+        }
+
+        if (ProxyToRanges.TryGetValue(proxy, out var ranges))
+        {
+            ranges.Remove(range);
+            if (ranges.Count == 0)
+            {
+                ProxyToRanges.Remove(proxy);
+            }
+        }
+
+        if (log && ModConfig.Instance.logShade)
+        {
+            try
+            {
+                string owner = GetOwnerName(range);
+                LegacyHelper.Instance?.Logger?.LogInfo($"Shade aggro proxy exited alert range '{range.name}' ({owner}).");
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static void Cleanup(AlertRange range)
+    {
+        if (range == null)
+        {
+            return;
+        }
+
+        if (!RangeToProxies.TryGetValue(range, out var proxies) || proxies.Count == 0)
+        {
+            RangeToProxies.Remove(range);
+            return;
+        }
+
+        proxies.RemoveWhere(p => p == null);
+        if (proxies.Count == 0)
+        {
+            RangeToProxies.Remove(range);
+            LegacyHelper.AlertRange_FixedUpdate_Patch.ResetLog(range);
+        }
+    }
+
+    private static string GetOwnerName(AlertRange range)
+    {
+        if (range == null)
+        {
+            return "unknown";
+        }
+
+        try
+        {
+            var owner = range.transform;
+            if (owner == null)
+            {
+                return "no transform";
+            }
+
+            var root = owner.root;
+            return root != null ? root.name : owner.name;
+        }
+        catch
+        {
+            return "unknown";
+        }
+    }
+}
+#nullable restore

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -4038,7 +4038,7 @@ public partial class LegacyHelper
             }
         }
 
-        private sealed class AggroProxyTracker : MonoBehaviour, ITrackTriggerObject
+        internal sealed class AggroProxyTracker : MonoBehaviour, ITrackTriggerObject
         {
             private ShadeController owner;
             private Collider2D proxyCollider;

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -154,12 +154,14 @@ public partial class LegacyHelper
             try
             {
                 int heroLayer = gameObject.layer;
+                string heroTag = null;
                 try
                 {
                     var hc = HeroController.instance;
                     if (hc && hc.gameObject)
                     {
                         heroLayer = hc.gameObject.layer;
+                        heroTag = hc.gameObject.tag;
                     }
                 }
                 catch
@@ -176,7 +178,11 @@ public partial class LegacyHelper
                 aggroProxy.transform.localRotation = Quaternion.identity;
                 aggroProxy.transform.localScale = Vector3.one;
                 aggroProxy.layer = heroLayer;
-                aggroProxy.tag = "Untagged";
+                if (string.IsNullOrEmpty(heroTag))
+                {
+                    heroTag = "Player";
+                }
+                aggroProxy.tag = heroTag;
 
                 var proxyCollider = aggroProxy.GetComponent<CapsuleCollider2D>();
                 if (!proxyCollider)

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -214,7 +214,7 @@ public partial class LegacyHelper
 
                 proxyCollider.size = size;
                 proxyCollider.offset = offset;
-                proxyCollider.enabled = !isInactive && isActiveAndEnabled;
+                proxyCollider.enabled = !isInactive && isActiveAndEnabled && !assistModeEnabled;
 
                 var tracker = aggroProxy.GetComponent<AggroProxyTracker>();
                 if (!tracker)
@@ -834,7 +834,7 @@ public partial class LegacyHelper
             EnsureAggroProxyCollider();
             if (aggroProxyCollider)
             {
-                bool proxyActive = !isInactive && isActiveAndEnabled;
+                bool proxyActive = !isInactive && isActiveAndEnabled && !assistModeEnabled;
                 if (aggroProxyCollider.enabled != proxyActive)
                 {
                     aggroProxyCollider.enabled = proxyActive;

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -188,7 +188,7 @@ public partial class LegacyHelper
 
         // Inactive state (at 0 HP)
         private bool isInactive;
-        internal bool IsAggroEligible => !isInactive && isActiveAndEnabled;
+        internal bool IsAggroEligible => !isInactive && isActiveAndEnabled && !assistModeEnabled;
         private bool isDying;
         private Coroutine deathRoutine;
 

--- a/LegacyHelper.ShadeController.Fields.cs
+++ b/LegacyHelper.ShadeController.Fields.cs
@@ -188,6 +188,7 @@ public partial class LegacyHelper
 
         // Inactive state (at 0 HP)
         private bool isInactive;
+        internal bool IsAggroEligible => !isInactive && isActiveAndEnabled;
         private bool isDying;
         private Coroutine deathRoutine;
 


### PR DESCRIPTION
## Summary
- add a hero-layer aggro proxy collider to the shade so nearby enemies can target it
- ensure the proxy collider is toggled based on the shade's active state and cleaned up on teardown

## Testing
- not run (in-game validation required)


------
https://chatgpt.com/codex/tasks/task_e_68d8a89bd5bc832088a2406dbc9ffccd