### PR TITLE
Fix shade proxy interactions with remaskers

### DIFF
--- a/LegacyHelper.Patches.cs
+++ b/LegacyHelper.Patches.cs
@@ -90,6 +90,62 @@ public partial class LegacyHelper
         }
     }
 
+    [HarmonyPatch(typeof(Remasker), "OnTriggerEnter2D")]
+    private static class Remasker_OnTriggerEnter2D_Patch
+    {
+        private static bool Prefix(Remasker __instance, Collider2D collision)
+        {
+            if (collision == null)
+            {
+                return true;
+            }
+
+            var tracker = collision.GetComponent<ShadeController.AggroProxyTracker>();
+            if (tracker == null)
+            {
+                return true;
+            }
+
+            try
+            {
+                tracker.NotifyRemaskerIgnored(__instance);
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Remasker), "OnTriggerExit2D")]
+    private static class Remasker_OnTriggerExit2D_Patch
+    {
+        private static bool Prefix(Remasker __instance, Collider2D collision)
+        {
+            if (collision == null)
+            {
+                return true;
+            }
+
+            var tracker = collision.GetComponent<ShadeController.AggroProxyTracker>();
+            if (tracker == null)
+            {
+                return true;
+            }
+
+            try
+            {
+                tracker.NotifyRemaskerIgnored(__instance);
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+    }
+
     [HarmonyPatch(typeof(AlertRange), "FixedUpdate")]
     internal static class AlertRange_FixedUpdate_Patch
     {

--- a/LegacyHelper.ShadeController.Core.cs
+++ b/LegacyHelper.ShadeController.Core.cs
@@ -4197,6 +4197,16 @@ public partial class LegacyHelper
                 RemaskerBuffer.Clear();
                 remaskersInside.Clear();
             }
+
+            internal void NotifyRemaskerIgnored(Remasker remasker)
+            {
+                if (!remasker)
+                {
+                    return;
+                }
+
+                remaskersInside.Remove(remasker);
+            }
         }
 
         private int GetHornetNailDamage()


### PR DESCRIPTION
## Summary
- prevent remaskers from reacting to the shade aggro proxy so darkness regions stay revealed when the companion moves or dies
- drop ignored remaskers from the tracker so forced cleanup no longer darkens rooms unexpectedly

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e09765db008320a6c106d303b7832e